### PR TITLE
Custom bar colors

### DIFF
--- a/image.c
+++ b/image.c
@@ -497,7 +497,7 @@ void img_render(img_t *img)
 			}
 			imlib_image_put_back_data(data);
 		} else {
-			c = win->bg_color.pixel;
+			c = win->win_bg.pixel;
 			imlib_context_set_color(c >> 16 & 0xFF, c >> 8 & 0xFF, c & 0xFF, 0xFF);
 			imlib_image_fill_rectangle(0, 0, dw, dh);
 		}

--- a/image.c
+++ b/image.c
@@ -497,7 +497,7 @@ void img_render(img_t *img)
 			}
 			imlib_image_put_back_data(data);
 		} else {
-			c = win->bg.pixel;
+			c = win->bg_color.pixel;
 			imlib_context_set_color(c >> 16 & 0xFF, c >> 8 & 0xFF, c & 0xFF, 0xFF);
 			imlib_image_fill_rectangle(0, 0, dw, dh);
 		}

--- a/sxiv.1
+++ b/sxiv.1
@@ -378,17 +378,17 @@ Zoom out.
 .SH CONFIGURATION
 The following X resources are supported:
 .TP
-.B background
+.B window.background
 Color of the window background
 .TP
-.B foreground
+.B window.foreground
 Color of the window foreground
 .TP
-.B bar
-Color of the bar background
+.B bar.background
+Color of the bar background. Defaults to window.foreground
 .TP
-.B text
-Color of the bar foreground
+.B bar.foreground
+Color of the bar foreground. Defaults to window.background
 .TP
 .B font
 Name of Xft bar font

--- a/sxiv.1
+++ b/sxiv.1
@@ -379,10 +379,16 @@ Zoom out.
 The following X resources are supported:
 .TP
 .B background
-Color of the window background and bar foreground
+Color of the window background
 .TP
 .B foreground
-Color of the window foreground and bar background
+Color of the window foreground
+.TP
+.B bar
+Color of the bar background
+.TP
+.B text
+Color of the bar foreground
 .TP
 .B font
 Name of Xft bar font

--- a/sxiv.h
+++ b/sxiv.h
@@ -407,8 +407,10 @@ struct win {
 	Window xwin;
 	win_env_t env;
 
-	XftColor bg;
-	XftColor fg;
+	XftColor bg_color;
+	XftColor fg_color;
+	XftColor bar_color;
+	XftColor text_color;
 
 	int x;
 	int y;

--- a/sxiv.h
+++ b/sxiv.h
@@ -407,10 +407,10 @@ struct win {
 	Window xwin;
 	win_env_t env;
 
-	XftColor bg_color;
-	XftColor fg_color;
-	XftColor bar_color;
-	XftColor text_color;
+	XftColor win_bg;
+	XftColor win_fg;
+	XftColor bar_bg;
+	XftColor bar_fg;
 
 	int x;
 	int y;

--- a/thumbs.c
+++ b/thumbs.c
@@ -469,14 +469,14 @@ void tns_mark(tns_t *tns, int n, bool mark)
 	if (n >= 0 && n < *tns->cnt && tns->thumbs[n].im != NULL) {
 		win_t *win = tns->win;
 		thumb_t *t = &tns->thumbs[n];
-		unsigned long col = win->bg.pixel;
+		unsigned long col = win->bg_color.pixel;
 		int x = t->x + t->w, y = t->y + t->h;
 
 		win_draw_rect(win, x - 1, y + 1, 1, tns->bw, true, 1, col);
 		win_draw_rect(win, x + 1, y - 1, tns->bw, 1, true, 1, col);
 
 		if (mark)
-			col = win->fg.pixel;
+			col = win->fg_color.pixel;
 
 		win_draw_rect(win, x, y, tns->bw + 2, tns->bw + 2, true, 1, col);
 
@@ -490,7 +490,7 @@ void tns_highlight(tns_t *tns, int n, bool hl)
 	if (n >= 0 && n < *tns->cnt && tns->thumbs[n].im != NULL) {
 		win_t *win = tns->win;
 		thumb_t *t = &tns->thumbs[n];
-		unsigned long col = hl ? win->fg.pixel : win->bg.pixel;
+		unsigned long col = hl ? win->fg_color.pixel : win->bg_color.pixel;
 		int oxy = (tns->bw + 1) / 2 + 1, owh = tns->bw + 2;
 
 		win_draw_rect(win, t->x - oxy, t->y - oxy, t->w + owh, t->h + owh,

--- a/thumbs.c
+++ b/thumbs.c
@@ -469,14 +469,14 @@ void tns_mark(tns_t *tns, int n, bool mark)
 	if (n >= 0 && n < *tns->cnt && tns->thumbs[n].im != NULL) {
 		win_t *win = tns->win;
 		thumb_t *t = &tns->thumbs[n];
-		unsigned long col = win->bg_color.pixel;
+		unsigned long col = win->win_bg.pixel;
 		int x = t->x + t->w, y = t->y + t->h;
 
 		win_draw_rect(win, x - 1, y + 1, 1, tns->bw, true, 1, col);
 		win_draw_rect(win, x + 1, y - 1, tns->bw, 1, true, 1, col);
 
 		if (mark)
-			col = win->fg_color.pixel;
+			col = win->win_fg.pixel;
 
 		win_draw_rect(win, x, y, tns->bw + 2, tns->bw + 2, true, 1, col);
 
@@ -490,7 +490,7 @@ void tns_highlight(tns_t *tns, int n, bool hl)
 	if (n >= 0 && n < *tns->cnt && tns->thumbs[n].im != NULL) {
 		win_t *win = tns->win;
 		thumb_t *t = &tns->thumbs[n];
-		unsigned long col = hl ? win->fg_color.pixel : win->bg_color.pixel;
+		unsigned long col = hl ? win->win_fg.pixel : win->win_bg.pixel;
 		int oxy = (tns->bw + 1) / 2 + 1, owh = tns->bw + 2;
 
 		win_draw_rect(win, t->x - oxy, t->y - oxy, t->w + owh, t->h + owh,

--- a/window.c
+++ b/window.c
@@ -121,8 +121,8 @@ void win_init(win_t *win)
 
 	win_bg = win_res(db, RES_CLASS ".window.background", "white");
 	win_fg = win_res(db, RES_CLASS ".window.foreground", "black");
-	bar_bg = win_res(db, RES_CLASS ".bar.background", win_fg);
-	bar_fg = win_res(db, RES_CLASS ".bar.foreground", win_bg);
+	bar_bg = win_res(db, RES_CLASS ".bar.background", win_bg);
+	bar_fg = win_res(db, RES_CLASS ".bar.foreground", win_fg);
 	win_alloc_color(e, win_bg, &win->win_bg);
 	win_alloc_color(e, win_fg, &win->win_fg);
 	win_alloc_color(e, bar_bg, &win->bar_bg);

--- a/window.c
+++ b/window.c
@@ -92,7 +92,7 @@ const char* win_res(XrmDatabase db, const char *name, const char *def)
 void win_init(win_t *win)
 {
 	win_env_t *e;
-	const char *bg_color, *fg_color, *bar_color, *text_color, *f;
+	const char *win_bg, *win_fg, *bar_bg, *bar_fg, *f;
 	char *res_man;
 	XrmDatabase db;
 
@@ -119,14 +119,14 @@ void win_init(win_t *win)
 	f = win_res(db, RES_CLASS ".font", "monospace-8");
 	win_init_font(e, f);
 
-	bg_color = win_res(db, RES_CLASS ".window.background", "white");
-	fg_color = win_res(db, RES_CLASS ".window.foreground", "black");
-	bar_color = win_res(db, RES_CLASS ".bar.background", fg_color);
-	text_color = win_res(db, RES_CLASS ".bar.foreground", bg_color);
-	win_alloc_color(e, bg_color, &win->bg_color);
-	win_alloc_color(e, fg_color, &win->fg_color);
-	win_alloc_color(e, bar_color, &win->bar_color);
-	win_alloc_color(e, text_color, &win->text_color);
+	win_bg = win_res(db, RES_CLASS ".window.background", "white");
+	win_fg = win_res(db, RES_CLASS ".window.foreground", "black");
+	bar_bg = win_res(db, RES_CLASS ".bar.background", win_fg);
+	bar_fg = win_res(db, RES_CLASS ".bar.foreground", win_bg);
+	win_alloc_color(e, win_bg, &win->win_bg);
+	win_alloc_color(e, win_fg, &win->win_fg);
+	win_alloc_color(e, bar_bg, &win->bar_bg);
+	win_alloc_color(e, bar_fg, &win->bar_fg);
 
 	win->bar.l.size = BAR_L_LEN;
 	win->bar.r.size = BAR_R_LEN;
@@ -262,7 +262,7 @@ void win_open(win_t *win)
 	win->buf.h = e->scrh;
 	win->buf.pm = XCreatePixmap(e->dpy, win->xwin,
 	                            win->buf.w, win->buf.h, e->depth);
-	XSetForeground(e->dpy, gc, win->bg_color.pixel);
+	XSetForeground(e->dpy, gc, win->win_bg.pixel);
 	XFillRectangle(e->dpy, win->buf.pm, gc, 0, 0, win->buf.w, win->buf.h);
 	XSetWindowBackgroundPixmap(e->dpy, win->xwin, win->buf.pm);
 
@@ -344,7 +344,7 @@ void win_clear(win_t *win)
 		win->buf.pm = XCreatePixmap(e->dpy, win->xwin,
 		                            win->buf.w, win->buf.h, e->depth);
 	}
-	XSetForeground(e->dpy, gc, win->bg_color.pixel);
+	XSetForeground(e->dpy, gc, win->win_bg.pixel);
 	XFillRectangle(e->dpy, win->buf.pm, gc, 0, 0, win->buf.w, win->buf.h);
 }
 
@@ -401,23 +401,23 @@ void win_draw_bar(win_t *win)
 	d = XftDrawCreate(e->dpy, win->buf.pm, DefaultVisual(e->dpy, e->scr),
 	                  DefaultColormap(e->dpy, e->scr));
 
-	XSetForeground(e->dpy, gc, win->bar_color.pixel);
+	XSetForeground(e->dpy, gc, win->bar_bg.pixel);
 	XFillRectangle(e->dpy, win->buf.pm, gc, 0, win->h, win->w, win->bar.h);
 
-	XSetForeground(e->dpy, gc, win->bg_color.pixel);
-	XSetBackground(e->dpy, gc, win->bar_color.pixel);
+	XSetForeground(e->dpy, gc, win->win_bg.pixel);
+	XSetBackground(e->dpy, gc, win->bar_bg.pixel);
 
 	if ((len = strlen(r->buf)) > 0) {
 		if ((tw = TEXTWIDTH(win, r->buf, len)) > w)
 			return;
 		x = win->w - tw - H_TEXT_PAD;
 		w -= tw;
-		win_draw_text(win, d, &win->text_color, x, y, r->buf, len, tw);
+		win_draw_text(win, d, &win->bar_fg, x, y, r->buf, len, tw);
 	}
 	if ((len = strlen(l->buf)) > 0) {
 		x = H_TEXT_PAD;
 		w -= 2 * H_TEXT_PAD; /* gap between left and right parts */
-		win_draw_text(win, d, &win->text_color, x, y, l->buf, len, w);
+		win_draw_text(win, d, &win->bar_fg, x, y, l->buf, len, w);
 	}
 	XftDrawDestroy(d);
 }

--- a/window.c
+++ b/window.c
@@ -119,10 +119,10 @@ void win_init(win_t *win)
 	f = win_res(db, RES_CLASS ".font", "monospace-8");
 	win_init_font(e, f);
 
-	bg_color = win_res(db, RES_CLASS ".background", "white");
-	fg_color = win_res(db, RES_CLASS ".foreground", "black");
-	bar_color = win_res(db, RES_CLASS ".bar", fg_color);
-	text_color = win_res(db, RES_CLASS ".text", bg_color);
+	bg_color = win_res(db, RES_CLASS ".window.background", "white");
+	fg_color = win_res(db, RES_CLASS ".window.foreground", "black");
+	bar_color = win_res(db, RES_CLASS ".bar.background", fg_color);
+	text_color = win_res(db, RES_CLASS ".bar.foreground", bg_color);
 	win_alloc_color(e, bg_color, &win->bg_color);
 	win_alloc_color(e, fg_color, &win->fg_color);
 	win_alloc_color(e, bar_color, &win->bar_color);


### PR DESCRIPTION
Set the bar colors independently from the bg/fg colors.

`.Xresources` (example):
```
Sxiv.bar: black
Sxiv.text: white
```

**Notes:**
Bar color and text color defaults to foreground and background colors respectively, so it wont break backwards compatibility.

I'm not sure about the name we should use in the Xresources file, it could be `bar/textColor` but since background/foreground does not have this suffix, I preferred not to.