### PR TITLE
set title based on prefix and suffix in xresources

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -6,18 +6,27 @@ enum {
 	WIN_HEIGHT = 600
 };
 
-#ifdef _OPTION_DEFAULTS
-/* default title prefix and suffix mode */
-static const char *TITLE_PREFIX = "sxiv - ";
-static const int TITLE_SUFFIXMODE = 1;
-#endif
-
 /* colors and font are configured with 'background', 'foreground' and
  * 'font' X resource properties.
  * See X(7) section Resources and xrdb(1) for more information.
  */
 
 #endif
+
+#ifdef _TITLE_CONFIG
+
+/* default title prefix */
+static const char *TITLE_PREFIX = "sxiv - ";
+
+/* default title suffixmode, available options are:
+ * SUFFIX_EMPTY
+ * SUFFIX_BASENAME
+ * SUFFIX_FULLPATH
+ */
+static const suffixmode_t TITLE_SUFFIXMODE = SUFFIX_BASENAME;
+
+#endif
+
 #ifdef _IMAGE_CONFIG
 
 /* levels (in percent) to use when zooming via '-' and '+':

--- a/config.def.h
+++ b/config.def.h
@@ -6,10 +6,6 @@ enum {
 	WIN_HEIGHT = 600
 };
 
-/* default title prefix and suffix mode */
-static const char *TITLE_PREFIX = "sxiv";
-static const int TITLE_SUFFIXMODE = 0;
-
 /* colors and font are configured with 'background', 'foreground' and
  * 'font' X resource properties.
  * See X(7) section Resources and xrdb(1) for more information.

--- a/config.def.h
+++ b/config.def.h
@@ -6,6 +6,12 @@ enum {
 	WIN_HEIGHT = 600
 };
 
+#ifdef _OPTION_DEFAULTS
+/* default title prefix and suffix mode */
+static const char *TITLE_PREFIX = "sxiv - ";
+static const int TITLE_SUFFIXMODE = 1;
+#endif
+
 /* colors and font are configured with 'background', 'foreground' and
  * 'font' X resource properties.
  * See X(7) section Resources and xrdb(1) for more information.

--- a/config.def.h
+++ b/config.def.h
@@ -6,6 +6,10 @@ enum {
 	WIN_HEIGHT = 600
 };
 
+/* default title prefix and suffix mode */
+static const char *TITLE_PREFIX = "sxiv";
+static const int TITLE_SUFFIXMODE = 0;
+
 /* colors and font are configured with 'background', 'foreground' and
  * 'font' X resource properties.
  * See X(7) section Resources and xrdb(1) for more information.

--- a/main.c
+++ b/main.c
@@ -314,6 +314,7 @@ void load_image(int new)
 	close_info();
 	open_info();
 	arl_setup(&arl, files[fileidx].path);
+	win_set_title(&win, files[fileidx].path);
 
 	if (img.multi.cnt > 0 && img.multi.animate)
 		set_timeout(animate, img.multi.frames[img.multi.sel].delay, true);
@@ -939,6 +940,7 @@ int main(int argc, char **argv)
 		load_image(fileidx);
 	}
 	win_open(&win);
+	win_set_title(&win, files[fileidx].path);
 	win_set_cursor(&win, CURSOR_WATCH);
 
 	atexit(cleanup);

--- a/options.c
+++ b/options.c
@@ -154,7 +154,7 @@ void parse_options(int argc, char **argv)
 				break;
 			case 'T':
 				if ((s = strrchr(optarg, ';')) != NULL) {
-					s[0] = '\0';
+					*s = '\0';
 					n = strtol(++s, &end, 0);
 					if (*end != '\0' || n < SUFFIX_EMPTY || n > SUFFIX_FULLPATH)
 						error(EXIT_FAILURE, 0, "Invalid argument for option -T suffixmode: %s", s);

--- a/options.c
+++ b/options.c
@@ -127,20 +127,6 @@ void parse_options(int argc, char **argv)
 			case 'N':
 				_options.res_name = optarg;
 				break;
-			case 'T':
-				if (*optarg == ';') {
-					_options.title_prefix = ++optarg;
-				} else {
-					if ((s = strchr(optarg, ';'))) {
-						s[0] = '\0';
-						_options.title_prefix = ++s;
-					}
-					n = strtol(optarg, &end, 0);
-					if (*end != '\0')
-						error(EXIT_FAILURE, 0, "Invalid argument for option -T suffixmode: %s", optarg);
-					_options.title_suffixmode = n;
-				}
-				break;
 			case 'o':
 				_options.to_stdout = true;
 				break;
@@ -164,6 +150,20 @@ void parse_options(int argc, char **argv)
 				if (s == NULL || *s == '\0' || strlen(optarg) != 1)
 					error(EXIT_FAILURE, 0, "Invalid argument for option -s: %s", optarg);
 				_options.scalemode = s - scalemodes;
+				break;
+			case 'T':
+				if (*optarg == ';') {
+					_options.title_prefix = ++optarg;
+				} else {
+					if ((s = strchr(optarg, ';'))) {
+						s[0] = '\0';
+						_options.title_prefix = ++s;
+					}
+					n = strtol(optarg, &end, 0);
+					if (*end != '\0')
+						error(EXIT_FAILURE, 0, "Invalid argument for option -T suffixmode: %s", optarg);
+					_options.title_suffixmode = n;
+				}
 				break;
 			case 't':
 				_options.thumb_mode = true;

--- a/options.c
+++ b/options.c
@@ -153,7 +153,7 @@ void parse_options(int argc, char **argv)
 				_options.scalemode = s - scalemodes;
 				break;
 			case 'T':
-				if ((s = strrchr(optarg, ';')) != NULL) {
+				if ((s = strrchr(optarg, ':')) != NULL) {
 					*s = '\0';
 					n = strtol(++s, &end, 0);
 					if (*end != '\0' || n < SUFFIX_EMPTY || n > SUFFIX_FULLPATH)

--- a/options.c
+++ b/options.c
@@ -156,14 +156,14 @@ void parse_options(int argc, char **argv)
 				if (*optarg == ';') {
 					_options.title_prefix = ++optarg;
 				} else {
-					if ((s = strchr(optarg, ';'))) {
+					if ((s = strrchr(optarg, ';')) != NULL) {
 						s[0] = '\0';
-						_options.title_prefix = ++s;
+						n = strtol(++s, &end, 0);
+						if (*end != '\0' || n < SUFFIX_EMPTY || n > SUFFIX_FULLPATH)
+							error(EXIT_FAILURE, 0, "Invalid argument for option -T suffixmode: %s", s);
+						_options.title_suffixmode = n;
 					}
-					n = strtol(optarg, &end, 0);
-					if (*end != '\0' || n < SUFFIX_EMPTY || n > SUFFIX_FULLPATH)
-						error(EXIT_FAILURE, 0, "Invalid argument for option -T suffixmode: %s", optarg);
-					_options.title_suffixmode = n;
+					_options.title_prefix = optarg;
 				}
 				break;
 			case 't':

--- a/options.c
+++ b/options.c
@@ -31,8 +31,8 @@ const opt_t *options = (const opt_t*) &_options;
 void print_usage(void)
 {
 	printf("usage: sxiv [-abcfhiopqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
-	       "[-g GEOMETRY] [-N NAME] [-n NUM] [-S DELAY] [-s MODE] [-z ZOOM] "
-	       "FILES...\n");
+	       "[-g GEOMETRY] [-N NAME] [-T TITLE] [-n NUM] [-S DELAY] [-s MODE] "
+	       "[-z ZOOM] FILES...\n");
 }
 
 void print_version(void)
@@ -66,13 +66,15 @@ void parse_options(int argc, char **argv)
 	_options.hide_bar = false;
 	_options.geometry = NULL;
 	_options.res_name = NULL;
+	_options.title_prefix = NULL;
+	_options.title_suffixmode = NULL;
 
 	_options.quiet = false;
 	_options.thumb_mode = false;
 	_options.clean_cache = false;
 	_options.private_mode = false;
 
-	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:opqrS:s:tvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:T:opqrS:s:tvZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -124,6 +126,16 @@ void parse_options(int argc, char **argv)
 				break;
 			case 'N':
 				_options.res_name = optarg;
+				break;
+			case 'T': ;
+				if (*optarg != ';') {
+					char *first = strtok(optarg, ";");
+					if (first != NULL) _options.title_prefix = first;
+					optarg = NULL;
+				}
+
+				char *seccond = strtok(optarg, ";");
+				if (seccond != NULL) _options.title_suffixmode = seccond;
 				break;
 			case 'o':
 				_options.to_stdout = true;

--- a/options.c
+++ b/options.c
@@ -153,18 +153,14 @@ void parse_options(int argc, char **argv)
 				_options.scalemode = s - scalemodes;
 				break;
 			case 'T':
-				if (*optarg == ';') {
-					_options.title_prefix = ++optarg;
-				} else {
-					if ((s = strrchr(optarg, ';')) != NULL) {
-						s[0] = '\0';
-						n = strtol(++s, &end, 0);
-						if (*end != '\0' || n < SUFFIX_EMPTY || n > SUFFIX_FULLPATH)
-							error(EXIT_FAILURE, 0, "Invalid argument for option -T suffixmode: %s", s);
-						_options.title_suffixmode = n;
-					}
-					_options.title_prefix = optarg;
+				if ((s = strrchr(optarg, ';')) != NULL) {
+					s[0] = '\0';
+					n = strtol(++s, &end, 0);
+					if (*end != '\0' || n < SUFFIX_EMPTY || n > SUFFIX_FULLPATH)
+						error(EXIT_FAILURE, 0, "Invalid argument for option -T suffixmode: %s", s);
+					_options.title_suffixmode = n;
 				}
+				_options.title_prefix = optarg;
 				break;
 			case 't':
 				_options.thumb_mode = true;

--- a/options.c
+++ b/options.c
@@ -128,16 +128,17 @@ void parse_options(int argc, char **argv)
 				_options.res_name = optarg;
 				break;
 			case 'T': ;
-				if (*optarg != ';') {
-					char *first = strtok(optarg, ";");
-					if (first != NULL) _options.title_suffixmode = first;
-					optarg = NULL;
+			    char *sep;
+				if (*optarg == ';') {
+					puts("1");
+					_options.title_prefix = ++optarg;
+				} else if ((sep = strchr(optarg, ';'))) {
+					sep[0] = '\0';
+					_options.title_suffixmode = optarg;
+					_options.title_prefix = ++sep;
 				} else {
-					optarg++;
+					_options.title_suffixmode = optarg;
 				}
-
-				char *second = strtok(optarg, "");
-				if (second != NULL) _options.title_prefix = second;
 				break;
 			case 'o':
 				_options.to_stdout = true;

--- a/options.c
+++ b/options.c
@@ -130,12 +130,14 @@ void parse_options(int argc, char **argv)
 			case 'T': ;
 				if (*optarg != ';') {
 					char *first = strtok(optarg, ";");
-					if (first != NULL) _options.title_prefix = first;
+					if (first != NULL) _options.title_suffixmode = first;
 					optarg = NULL;
+				} else {
+					optarg++;
 				}
 
-				char *second = strtok(optarg, ";");
-				if (second != NULL) _options.title_suffixmode = second;
+				char *second = strtok(optarg, "");
+				if (second != NULL) _options.title_prefix = second;
 				break;
 			case 'o':
 				_options.to_stdout = true;

--- a/options.c
+++ b/options.c
@@ -18,8 +18,7 @@
 
 #include "sxiv.h"
 #define _IMAGE_CONFIG
-#define _WINDOW_CONFIG
-#define _OPTION_DEFAULTS
+#define _TITLE_CONFIG
 #include "config.h"
 #include "version.h"
 

--- a/options.c
+++ b/options.c
@@ -127,8 +127,8 @@ void parse_options(int argc, char **argv)
 			case 'N':
 				_options.res_name = optarg;
 				break;
-			case 'T': ;
-			    char *sep;
+			case 'T':
+				char *sep;
 				if (*optarg == ';') {
 					puts("1");
 					_options.title_prefix = ++optarg;

--- a/options.c
+++ b/options.c
@@ -75,7 +75,7 @@ void parse_options(int argc, char **argv)
 	_options.clean_cache = false;
 	_options.private_mode = false;
 
-	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:T:opqrS:s:tvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:opqrS:s:T:tvZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();

--- a/options.c
+++ b/options.c
@@ -161,7 +161,7 @@ void parse_options(int argc, char **argv)
 						_options.title_prefix = ++s;
 					}
 					n = strtol(optarg, &end, 0);
-					if (*end != '\0')
+					if (*end != '\0' || n < SUFFIX_EMPTY || n > SUFFIX_FULLPATH)
 						error(EXIT_FAILURE, 0, "Invalid argument for option -T suffixmode: %s", optarg);
 					_options.title_suffixmode = n;
 				}

--- a/options.c
+++ b/options.c
@@ -66,8 +66,8 @@ void parse_options(int argc, char **argv)
 	_options.hide_bar = false;
 	_options.geometry = NULL;
 	_options.res_name = NULL;
-	_options.title_prefix = NULL;
-	_options.title_suffixmode = NULL;
+	_options.title_prefix = "sxiv - ";
+	_options.title_suffixmode = SUFFIX_BASENAME;
 
 	_options.quiet = false;
 	_options.thumb_mode = false;
@@ -127,17 +127,18 @@ void parse_options(int argc, char **argv)
 			case 'N':
 				_options.res_name = optarg;
 				break;
-			case 'T': ;
-				char *sep;
+			case 'T':
 				if (*optarg == ';') {
-					puts("1");
 					_options.title_prefix = ++optarg;
-				} else if ((sep = strchr(optarg, ';'))) {
-					sep[0] = '\0';
-					_options.title_suffixmode = optarg;
-					_options.title_prefix = ++sep;
 				} else {
-					_options.title_suffixmode = optarg;
+					if ((s = strchr(optarg, ';'))) {
+						s[0] = '\0';
+						_options.title_prefix = ++s;
+					}
+					n = strtol(optarg, &end, 0);
+					if (*end != '\0')
+						error(EXIT_FAILURE, 0, "Invalid argument for option -T suffixmode: %s", optarg);
+					_options.title_suffixmode = n;
 				}
 				break;
 			case 'o':

--- a/options.c
+++ b/options.c
@@ -127,7 +127,7 @@ void parse_options(int argc, char **argv)
 			case 'N':
 				_options.res_name = optarg;
 				break;
-			case 'T':
+			case 'T': ;
 				char *sep;
 				if (*optarg == ';') {
 					puts("1");

--- a/options.c
+++ b/options.c
@@ -18,6 +18,8 @@
 
 #include "sxiv.h"
 #define _IMAGE_CONFIG
+#define _WINDOW_CONFIG
+#define _OPTION_DEFAULTS
 #include "config.h"
 #include "version.h"
 
@@ -66,8 +68,8 @@ void parse_options(int argc, char **argv)
 	_options.hide_bar = false;
 	_options.geometry = NULL;
 	_options.res_name = NULL;
-	_options.title_prefix = "sxiv - ";
-	_options.title_suffixmode = SUFFIX_BASENAME;
+	_options.title_prefix = TITLE_PREFIX;
+	_options.title_suffixmode = TITLE_SUFFIXMODE;
 
 	_options.quiet = false;
 	_options.thumb_mode = false;

--- a/options.c
+++ b/options.c
@@ -134,8 +134,8 @@ void parse_options(int argc, char **argv)
 					optarg = NULL;
 				}
 
-				char *seccond = strtok(optarg, ";");
-				if (seccond != NULL) _options.title_suffixmode = seccond;
+				char *second = strtok(optarg, ";");
+				if (second != NULL) _options.title_suffixmode = second;
 				break;
 			case 'o':
 				_options.to_stdout = true;

--- a/sxiv.1
+++ b/sxiv.1
@@ -393,6 +393,20 @@ Color of the bar background. Defaults to window.foreground
 .B bar.foreground
 Color of the bar foreground. Defaults to window.background
 .TP
+.B title.prefix
+Any string literal to be used as the window title prefix. Defaults to "sxiv"
+.TP
+.B title.suffix
+The format of the window title suffix.
+.EX
+    Value  Format
+    0      Basename of file
+    1      Basename of directory
+    2      Full path to file
+    3      Full path to directory
+    4      Empty string
+.EE
+.TP
 .B font
 Name of Xft bar font
 .TP

--- a/sxiv.1
+++ b/sxiv.1
@@ -67,7 +67,7 @@ more information on GEOMETRY argument.
 Set the resource name of sxiv's X window to NAME.
 .TP
 .BI "\-T " TITLE
-Set the window title to TITLE. Use the format `prefix;suffixmode'.
+Set the window title to TITLE. Use the format `suffixmode;prefix'.
 .TP
 .BI "\-n " NUM
 Start at picture number NUM.

--- a/sxiv.1
+++ b/sxiv.1
@@ -14,6 +14,8 @@ sxiv \- Simple X Image Viewer
 .IR GEOMETRY ]
 .RB [ \-N
 .IR NAME ]
+.RB [ \-T
+.IR TITLE ]
 .RB [ \-n
 .IR NUM ]
 .RB [ \-S
@@ -63,6 +65,9 @@ more information on GEOMETRY argument.
 .TP
 .BI "\-N " NAME
 Set the resource name of sxiv's X window to NAME.
+.TP
+.BI "\-T " TITLE
+Set the window title to TITLE. Use the format `prefix;suffixmode'.
 .TP
 .BI "\-n " NUM
 Start at picture number NUM.

--- a/sxiv.1
+++ b/sxiv.1
@@ -67,7 +67,8 @@ more information on GEOMETRY argument.
 Set the resource name of sxiv's X window to NAME.
 .TP
 .BI "\-T " TITLE
-Set the window title to TITLE. Use the format `suffixmode;prefix'.
+Set the window title to TITLE. Use the format `suffixmode;prefix'. See title
+entries in section CONFIGURATION for more information.
 .TP
 .BI "\-n " NUM
 Start at picture number NUM.

--- a/sxiv.1
+++ b/sxiv.1
@@ -407,10 +407,8 @@ The format of the window title suffixmode.
 .EX
     Value  Format
     0      Basename of file
-    1      Basename of directory
-    2      Full path to file
-    3      Full path to directory
-    4      Empty string
+    1      Full path to file
+    2      Empty string
 .EE
 .TP
 .B font

--- a/sxiv.1
+++ b/sxiv.1
@@ -67,8 +67,14 @@ more information on GEOMETRY argument.
 Set the resource name of sxiv's X window to NAME.
 .TP
 .BI "\-T " TITLE
-Set the window title to TITLE. Use the format `suffixmode;prefix'. See title
-entries in section CONFIGURATION for more information.
+Set the window title to TITLE. Use the format `suffixmode;prefix'. Any string
+literal is accepted for prefix, and the format of suffixmode is:
+.EX
+    Value  Format
+    0      Empty
+    1      Basename of file
+    2      Full path to file
+.EE
 .TP
 .BI "\-n " NUM
 Start at picture number NUM.
@@ -398,18 +404,6 @@ Color of the bar background. Defaults to window.foreground
 .TP
 .B bar.foreground
 Color of the bar foreground. Defaults to window.background
-.TP
-.B title.prefix
-Any string literal to be used as the window title prefix. Defaults to "sxiv"
-.TP
-.B title.suffixmode
-The format of the window title suffixmode.
-.EX
-    Value  Format
-    0      Basename of file
-    1      Full path to file
-    2      Empty string
-.EE
 .TP
 .B font
 Name of Xft bar font

--- a/sxiv.1
+++ b/sxiv.1
@@ -69,12 +69,15 @@ Set the resource name of sxiv's X window to NAME.
 .BI "\-T " TITLE
 Set the window title to TITLE. Use the format `prefix:suffixmode'. Any string
 literal is accepted for prefix, and the format of suffixmode is:
+
 .EX
     Value  Format
     0      Empty
     1      Basename of file
     2      Full path to file
 .EE
+
+By defualt, prefix is set to "sxiv - " and suffixmode is set to 1 (basename).
 .TP
 .BI "\-n " NUM
 Start at picture number NUM.

--- a/sxiv.1
+++ b/sxiv.1
@@ -67,7 +67,7 @@ more information on GEOMETRY argument.
 Set the resource name of sxiv's X window to NAME.
 .TP
 .BI "\-T " TITLE
-Set the window title to TITLE. Use the format `prefix;suffixmode'. Any string
+Set the window title to TITLE. Use the format `prefix:suffixmode'. Any string
 literal is accepted for prefix, and the format of suffixmode is:
 .EX
     Value  Format

--- a/sxiv.1
+++ b/sxiv.1
@@ -401,8 +401,8 @@ Color of the bar foreground. Defaults to window.background
 .B title.prefix
 Any string literal to be used as the window title prefix. Defaults to "sxiv"
 .TP
-.B title.suffix
-The format of the window title suffix.
+.B title.suffixmode
+The format of the window title suffixmode.
 .EX
     Value  Format
     0      Basename of file

--- a/sxiv.1
+++ b/sxiv.1
@@ -67,7 +67,7 @@ more information on GEOMETRY argument.
 Set the resource name of sxiv's X window to NAME.
 .TP
 .BI "\-T " TITLE
-Set the window title to TITLE. Use the format `suffixmode;prefix'. Any string
+Set the window title to TITLE. Use the format `prefix;suffixmode'. Any string
 literal is accepted for prefix, and the format of suffixmode is:
 .EX
     Value  Format

--- a/sxiv.h
+++ b/sxiv.h
@@ -118,9 +118,7 @@ typedef enum {
 
 typedef enum {
 	BASE_CFILE,
-	BASE_CDIR,
 	CFILE,
-	CDIR,
 	EMPTY,
 
 	SUFFIXMODE_COUNT,

--- a/sxiv.h
+++ b/sxiv.h
@@ -290,6 +290,8 @@ struct opt {
 	long embed;
 	char *geometry;
 	char *res_name;
+	char *title_prefix;
+	char *title_suffixmode;
 
 	/* misc flags: */
 	bool quiet;

--- a/sxiv.h
+++ b/sxiv.h
@@ -117,11 +117,9 @@ typedef enum {
 } fileflags_t;
 
 typedef enum {
-	BASE_CFILE,
-	CFILE,
-	EMPTY,
-
-	SUFFIXMODE_COUNT,
+	SUFFIX_EMPTY,
+	SUFFIX_BASENAME,
+	SUFFIX_FULLPATH,
 } suffixmode_t;
 
 typedef struct {
@@ -289,7 +287,7 @@ struct opt {
 	char *geometry;
 	char *res_name;
 	char *title_prefix;
-	char *title_suffixmode;
+	suffixmode_t title_suffixmode;
 
 	/* misc flags: */
 	bool quiet;
@@ -423,10 +421,6 @@ struct win {
 	XftColor win_fg;
 	XftColor bar_bg;
 	XftColor bar_fg;
-
-	suffixmode_t title_suffixmode;
-	const char   *title_prefix;
-	const char   *title_suffix;
 
 	int x;
 	int y;

--- a/sxiv.h
+++ b/sxiv.h
@@ -116,6 +116,16 @@ typedef enum {
 	FF_TN_INIT = 4
 } fileflags_t;
 
+typedef enum {
+	BASE_CFILE,
+	BASE_CDIR,
+	CFILE,
+	CDIR,
+	EMPTY,
+
+	SUFFIXMODE_COUNT,
+} suffixmode_t;
+
 typedef struct {
 	const char *name; /* as given by user */
 	const char *path; /* always absolute */
@@ -413,6 +423,10 @@ struct win {
 	XftColor win_fg;
 	XftColor bar_bg;
 	XftColor bar_fg;
+
+	suffixmode_t title_suffixmode;
+	const char   *title_prefix;
+	const char   *title_suffix;
 
 	int x;
 	int y;

--- a/sxiv.h
+++ b/sxiv.h
@@ -286,7 +286,7 @@ struct opt {
 	long embed;
 	char *geometry;
 	char *res_name;
-	char *title_prefix;
+	const char *title_prefix;
 	suffixmode_t title_suffixmode;
 
 	/* misc flags: */

--- a/thumbs.c
+++ b/thumbs.c
@@ -35,6 +35,7 @@ void exif_auto_orientate(const fileinfo_t*);
 Imlib_Image img_open(const fileinfo_t*);
 
 static char *cache_dir;
+extern const int fileidx;
 
 char* tns_cache_filepath(const char *filepath)
 {
@@ -531,6 +532,7 @@ bool tns_move_selection(tns_t *tns, direction_t dir, int cnt)
 		if (!tns->dirty)
 			tns_highlight(tns, *tns->sel, true);
 	}
+	win_set_title(tns->win, tns->files[fileidx].path);
 	return *tns->sel != old;
 }
 

--- a/window.c
+++ b/window.c
@@ -490,16 +490,17 @@ void win_draw_rect(win_t *win, int x, int y, int w, int h, bool fill, int lw,
 
 void win_set_title(win_t *win, const char *path)
 {
-	char title[PATH_MAX];
+	const int title_max = strlen(path) + strlen(options->title_prefix) + 1;
+	char title[title_max];
 	const char *basename = strrchr(path, '/');
 
 	/* Return if window is not ready yet, otherwise we get an X fault. */
-	if (win->xwin == None || basename == NULL)
+	if (win->xwin == None)
 		return;
 
 	/* Some ancient WM's that don't comply to EMWH (e.g. mwm) only use WM_NAME for
 	 * the window title, which is set by XStoreName below. */
-	snprintf(title, PATH_MAX, "%s%s", options->title_prefix,
+	snprintf(title, title_max, "%s%s", options->title_prefix,
 	        (options->title_suffixmode == SUFFIX_BASENAME) ? basename+1 : path);
 	if (options->title_suffixmode == SUFFIX_EMPTY)
 		*(title+strlen(options->title_prefix)) = '\0';

--- a/window.c
+++ b/window.c
@@ -145,12 +145,15 @@ void win_init(win_t *win)
 		win->title_prefix = TITLE_PREFIX;
 	}
 
-	if (options->title_suffixmode != NULL) {
-		win->title_suffixmode = strtol(options->title_suffixmode, NULL, 10) % SUFFIXMODE_COUNT;
-	} else if (title_suffixmode != NULL) {
-		win->title_suffixmode = strtol(title_suffixmode, NULL, 10) % SUFFIXMODE_COUNT;
-	} else {
+	if (options->title_suffixmode == NULL && title_suffixmode == NULL) {
 		win->title_suffixmode = TITLE_SUFFIXMODE % SUFFIXMODE_COUNT;
+	} else {
+		char *endptr;
+		const char *nptr = options->title_suffixmode != NULL
+						 ? options->title_suffixmode : title_suffixmode;
+		win->title_suffixmode = strtol(nptr, &endptr, 10) % SUFFIXMODE_COUNT;
+		if (nptr == endptr)
+			fputs("sxiv: invalid suffixmode, assuming 0\n", stderr);
 	}
 
 	win_bg = win_res(db, RES_CLASS ".window.background", "white");

--- a/window.c
+++ b/window.c
@@ -497,7 +497,6 @@ void win_set_title(win_t *win, const char *path)
 	if (win->xwin == None)
 		return;
 
-	/* Get title suffix type from X-resources. Default: SUFFIX_BASENAME. */
 	switch (options->title_suffixmode) {
 		case SUFFIX_EMPTY:
 			suffix = "";

--- a/window.c
+++ b/window.c
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <libgen.h>
 #include <locale.h>
 #include <unistd.h>
 #include <X11/cursorfont.h>
@@ -132,6 +133,11 @@ void win_init(win_t *win)
 
 	f = win_res(db, RES_CLASS ".font", "monospace-8");
 	win_init_font(e, f);
+
+	win->title_prefix = win_res(db, RES_CLASS ".title.prefix", "sxiv");
+	win->title_suffixmode = strtol(win_res(db, RES_CLASS ".title.suffix", "0"),
+	                         NULL, 10) % SUFFIXMODE_COUNT;
+
 
 	win_bg = win_res(db, RES_CLASS ".window.background", "white");
 	win_fg = win_res(db, RES_CLASS ".window.foreground", "black");
@@ -275,8 +281,6 @@ void win_open(win_t *win)
 		                (unsigned char *) icon_data, n);
 	}
 	free(icon_data);
-
-	win_set_title(win, "sxiv");
 
 	classhint.res_class = RES_CLASS;
 	classhint.res_name = options->res_name != NULL ? options->res_name : "sxiv";
@@ -486,17 +490,58 @@ void win_draw_rect(win_t *win, int x, int y, int w, int h, bool fill, int lw,
 		XDrawRectangle(win->env.dpy, win->buf.pm, gc, x, y, w, h);
 }
 
-void win_set_title(win_t *win, const char *title)
+void win_set_title(win_t *win, const char *path)
 {
-	XStoreName(win->env.dpy, win->xwin, title);
-	XSetIconName(win->env.dpy, win->xwin, title);
+	char *title, *suffix="";
+	static bool first_time = true;
 
+	/* Return if window is not ready yet, otherwise we get an X fault. */
+	if (win->xwin == None)
+		return;
+
+	/* Get title suffix type from X-resources. Default: BASE_CDIR. */
+	suffix = estrdup(path);
+	switch (win->title_suffixmode) {
+		case CFILE:
+			win->title_suffix = suffix;
+			break;
+		case BASE_CFILE:
+			win->title_suffix = basename(suffix);
+			break;
+		case CDIR:
+			win->title_suffix = dirname(suffix);
+			break;
+		case BASE_CDIR:
+			win->title_suffix = basename(dirname(suffix));
+			break;
+		case SUFFIXMODE_COUNT: // Never happens
+		case EMPTY:
+			win->title_suffix = "";
+			break;
+	}
+
+	/* Some ancient WM's that don't comply to EMWH (e.g. mwm) only use WM_NAME for
+	 * the window title, which is set by XStoreName below. */
+	size_t prefixLen = strlen(win->title_prefix);
+	size_t suffixLen = strlen(win->title_suffix);
+	const char *separator = (suffixLen == 0 || prefixLen == 0) ? "" : " - ";
+	title = emalloc(prefixLen + strlen(separator) + suffixLen + 1);
+	sprintf(title, "%s%s%s", win->title_prefix, separator, win->title_suffix);
 	XChangeProperty(win->env.dpy, win->xwin, atoms[ATOM__NET_WM_NAME],
 	                XInternAtom(win->env.dpy, "UTF8_STRING", False), 8,
-	                PropModeReplace, (unsigned char *) title, strlen(title));
+	                PropModeReplace, (unsigned char *)title, strlen(title));
 	XChangeProperty(win->env.dpy, win->xwin, atoms[ATOM__NET_WM_ICON_NAME],
 	                XInternAtom(win->env.dpy, "UTF8_STRING", False), 8,
-	                PropModeReplace, (unsigned char *) title, strlen(title));
+	                PropModeReplace, (unsigned char *)title, strlen(title));
+	free(title);
+	free(suffix);
+
+	/* These two atoms won't change and thus only need to be set once. */
+	if (first_time) {
+		XStoreName(win->env.dpy, win->xwin, "sxiv");
+		XSetIconName(win->env.dpy, win->xwin, "sxiv");
+		first_time = false;
+	}
 }
 
 void win_set_cursor(win_t *win, cursor_t cursor)

--- a/window.c
+++ b/window.c
@@ -532,10 +532,10 @@ void win_set_title(win_t *win, const char *path)
 	sprintf(title, "%s%s%s", win->title_prefix, separator, win->title_suffix);
 	XChangeProperty(win->env.dpy, win->xwin, atoms[ATOM__NET_WM_NAME],
 	                XInternAtom(win->env.dpy, "UTF8_STRING", False), 8,
-	                PropModeReplace, (unsigned char *)title, strlen(title));
+	                PropModeReplace, (unsigned char *) title, strlen(title));
 	XChangeProperty(win->env.dpy, win->xwin, atoms[ATOM__NET_WM_ICON_NAME],
 	                XInternAtom(win->env.dpy, "UTF8_STRING", False), 8,
-	                PropModeReplace, (unsigned char *)title, strlen(title));
+	                PropModeReplace, (unsigned char *) title, strlen(title));
 	free(title);
 	free(suffix);
 }

--- a/window.c
+++ b/window.c
@@ -135,7 +135,7 @@ void win_init(win_t *win)
 	win_init_font(e, f);
 
 	const char *title_prefix = win_res(db, RES_CLASS ".title.prefix", NULL);
-	const char *title_suffixmode = win_res(db, RES_CLASS ".title.suffix", NULL);
+	const char *title_suffixmode = win_res(db, RES_CLASS ".title.suffixmode", NULL);
 
 	if (options->title_prefix != NULL) {
 		win->title_prefix = options->title_prefix;

--- a/window.c
+++ b/window.c
@@ -282,6 +282,10 @@ void win_open(win_t *win)
 	}
 	free(icon_data);
 
+	/* These two atoms won't change and thus only need to be set once. */
+	XStoreName(win->env.dpy, win->xwin, "sxiv");
+	XSetIconName(win->env.dpy, win->xwin, "sxiv");
+
 	classhint.res_class = RES_CLASS;
 	classhint.res_name = options->res_name != NULL ? options->res_name : "sxiv";
 	XSetClassHint(e->dpy, win->xwin, &classhint);
@@ -493,7 +497,6 @@ void win_draw_rect(win_t *win, int x, int y, int w, int h, bool fill, int lw,
 void win_set_title(win_t *win, const char *path)
 {
 	char *title, *suffix="";
-	static bool first_time = true;
 
 	/* Return if window is not ready yet, otherwise we get an X fault. */
 	if (win->xwin == None)
@@ -535,13 +538,6 @@ void win_set_title(win_t *win, const char *path)
 	                PropModeReplace, (unsigned char *)title, strlen(title));
 	free(title);
 	free(suffix);
-
-	/* These two atoms won't change and thus only need to be set once. */
-	if (first_time) {
-		XStoreName(win->env.dpy, win->xwin, "sxiv");
-		XSetIconName(win->env.dpy, win->xwin, "sxiv");
-		first_time = false;
-	}
 }
 
 void win_set_cursor(win_t *win, cursor_t cursor)

--- a/window.c
+++ b/window.c
@@ -134,10 +134,24 @@ void win_init(win_t *win)
 	f = win_res(db, RES_CLASS ".font", "monospace-8");
 	win_init_font(e, f);
 
-	win->title_prefix = win_res(db, RES_CLASS ".title.prefix", "sxiv");
-	win->title_suffixmode = strtol(win_res(db, RES_CLASS ".title.suffix", "0"),
-	                         NULL, 10) % SUFFIXMODE_COUNT;
+	const char *title_prefix = win_res(db, RES_CLASS ".title.prefix", NULL);
+	const char *title_suffixmode = win_res(db, RES_CLASS ".title.suffix", NULL);
 
+	if (options->title_prefix != NULL) {
+		win->title_prefix = options->title_prefix;
+	} else if (title_prefix != NULL) {
+		win->title_prefix = title_prefix;
+	} else {
+		win->title_prefix = TITLE_PREFIX;
+	}
+
+	if (options->title_suffixmode != NULL) {
+		win->title_suffixmode = strtol(options->title_suffixmode, NULL, 10) % SUFFIXMODE_COUNT;
+	} else if (title_suffixmode != NULL) {
+		win->title_suffixmode = strtol(title_suffixmode, NULL, 10) % SUFFIXMODE_COUNT;
+	} else {
+		win->title_suffixmode = TITLE_SUFFIXMODE % SUFFIXMODE_COUNT;
+	}
 
 	win_bg = win_res(db, RES_CLASS ".window.background", "white");
 	win_fg = win_res(db, RES_CLASS ".window.foreground", "black");

--- a/window.c
+++ b/window.c
@@ -525,12 +525,6 @@ void win_set_title(win_t *win, const char *path)
 		case BASE_CFILE:
 			win->title_suffix = basename(suffix);
 			break;
-		case CDIR:
-			win->title_suffix = dirname(suffix);
-			break;
-		case BASE_CDIR:
-			win->title_suffix = basename(dirname(suffix));
-			break;
 		case SUFFIXMODE_COUNT: // Never happens
 		case EMPTY:
 			win->title_suffix = "";

--- a/window.c
+++ b/window.c
@@ -490,18 +490,16 @@ void win_draw_rect(win_t *win, int x, int y, int w, int h, bool fill, int lw,
 
 void win_set_title(win_t *win, const char *path)
 {
-	const int title_max = strlen(path) + strlen(options->title_prefix) + 1;
+	const unsigned int title_max = strlen(path) + strlen(options->title_prefix) + 1;
 	char title[title_max];
-	const char *basename = strrchr(path, '/');
+	const char *basename = strrchr(path, '/') + 1;
 
-	/* Return if window is not ready yet, otherwise we get an X fault. */
+	/* Return if window is not ready yet */
 	if (win->xwin == None)
 		return;
 
-	/* Some ancient WM's that don't comply to EMWH (e.g. mwm) only use WM_NAME for
-	 * the window title, which is set by XStoreName below. */
 	snprintf(title, title_max, "%s%s", options->title_prefix,
-	        (options->title_suffixmode == SUFFIX_BASENAME) ? basename+1 : path);
+	        (options->title_suffixmode == SUFFIX_BASENAME) ? basename : path);
 	if (options->title_suffixmode == SUFFIX_EMPTY)
 		*(title+strlen(options->title_prefix)) = '\0';
 


### PR DESCRIPTION
The title is broken in a literal prefix and in a path suffix.
Both can be configured via X-resources.

https://github.com/muennich/sxiv/pull/453#issue-906753721
For those who use window managers (e.g. dwm, icewm) that show window titles, it may be useful to show the current file name in the title. This PR breaks the title in a string literal prefix and a suffix that shows a file path component, both X-resources configurable.

The a separator (" - ") in only set if needed.

```
sxiv - fileInView.png
^^^^^^^
prefix ^^^^^^^^^^^^^^
           suffix
```

The suffix can be the filename, its full path, its directory name, its directory full path, or, to keep backwards compatibility, nothing. Please see the manual for more detailed information.