### PR TITLE
Add an editorconfig file, closes #25

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig
+
+# apply to all files
+[*]
+
+# top-most EditorConfig file
+root = true
+
+# Set default charset
+charset = utf-8
+
+# Indentation
+# indent with tabs
+indent_style = tab
+# same tab size as kernel style
+indent_size = 8
+
+# no trailing spaces
+trim_trailing_whitespace = true
+
+# line lenght, same as kernel stipulated
+max_line_length = 100
+
+# all files have a final line
+insert_final_newline = true
+
+# end of line
+end_of_line = lf


### PR DESCRIPTION
this should take care of coding style inconsistencies, when we add the contribution guidelines to the readme there should be a mention to use the editorconfig plugin for your editor of choice in order to facilitate following the coding style. 