### PR TITLE
fix: out-of-bounds access when bg not in color map

### DIFF
--- a/image.c
+++ b/image.c
@@ -205,6 +205,10 @@ bool img_load_gif(img_t *img, const fileinfo_t *file)
 
 			ptr = data = (DATA32*) emalloc(sizeof(DATA32) * sw * sh);
 			cmap = gif->Image.ColorMap ? gif->Image.ColorMap : gif->SColorMap;
+			if (bg >= cmap->ColorCount) {
+				err = true;
+				break;
+			}
 			r = cmap->Colors[bg].Red;
 			g = cmap->Colors[bg].Green;
 			b = cmap->Colors[bg].Blue;


### PR DESCRIPTION
Reported by @whowillbellthecat in https://github.com/muennich/sxiv/issues/400

> The original issue I encounted was a segfault (occurs approx. 1 in 10 attempts) after accidently opening a particular 1 pixel tracking gif.
> As base64: `R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==`
> Stacktrace:
> 
> ```
> #0  0x000006e1c8972a68 in img_load_gif (img=0x6e1c8983040, file=0x6e48b17bfe0) at image.c:208
> #1  0x000006e1c89731f7 in img_load (img=0x6e1c8983040, file=0x6e48b17bfe0) at image.c:334
> #2  0x000006e1c8975ea9 in load_image (new=0) at main.c:304
> #3  0x000006e1c8978766 in main (argc=2, argv=0x7f7ffffdfae8) at main.c:939
> ```
> 
> The offending expression is `cmap->Colors[bg].Red` (in `img_load_gif` in `image.c`). In the example gif, `cmap->ColorCount` is 2, but `bg` is set to 255. I don't know if this should occur in a 'valid' gif (maybe with transparency(?), though the example gif looks to have the transparency index set to 0). I ended up patching it locally as an error with:
> 
> ```
> Index: image.c
> --- image.c.orig
> +++ image.c
> @@ -205,6 +205,10 @@ bool img_load_gif(img_t *img, const fileinfo_t *file)
>  
>  			ptr = data = (DATA32*) emalloc(sizeof(DATA32) * sw * sh);
>  			cmap = gif->Image.ColorMap ? gif->Image.ColorMap : gif->SColorMap;
> +			if (bg >= cmap->ColorCount) {
> +				err = true;
> +				break;
> +			}
>  			r = cmap->Colors[bg].Red;
>  			g = cmap->Colors[bg].Green;
>  			b = cmap->Colors[bg].Blue;
> ```
> 
> Which seems to work okayish (no segfaults).