### PR TITLE
Add dmenu mode, and new keybinding to print filename and quit

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -207,6 +207,8 @@ bool cg_reverse_marks(arg_t _)
 {
 	int i;
 
+	if (options->dmenu)
+		return false;
 	for (i = 0; i < filecnt; i++) {
 		files[i].flags ^= FF_MARK;
 		markcnt += files[i].flags & FF_MARK ? 1 : -1;
@@ -230,6 +232,8 @@ bool cg_unmark_all(arg_t _)
 {
 	int i;
 
+	if (options->dmenu)
+		return false;
 	for (i = 0; i < filecnt; i++)
 		files[i].flags &= ~FF_MARK;
 	markcnt = 0;

--- a/commands.c
+++ b/commands.c
@@ -85,6 +85,12 @@ bool cg_switch_mode(arg_t _)
 	return true;
 }
 
+bool cg_pick_quit(arg_t _)
+{
+	printf("%s\n", files[fileidx].name);
+	exit(EXIT_SUCCESS);
+}
+
 bool cg_toggle_fullscreen(arg_t _)
 {
 	win_toggle_fullscreen(&win);

--- a/commands.lst
+++ b/commands.lst
@@ -1,5 +1,6 @@
 G_CMD(quit)
 G_CMD(switch_mode)
+G_CMD(pick_quit)
 G_CMD(toggle_fullscreen)
 G_CMD(toggle_bar)
 G_CMD(prefix_external)

--- a/config.def.h
+++ b/config.def.h
@@ -72,6 +72,7 @@ static const keymap_t keys[] = {
 	/* modifiers    key               function              argument */
 	{ 0,            XK_q,             g_quit,               None },
 	{ 0,            XK_Return,        g_switch_mode,        None },
+	{ ShiftMask,    XK_Return,        g_pick_quit,          None },
 	{ 0,            XK_f,             g_toggle_fullscreen,  None },
 	{ 0,            XK_b,             g_toggle_bar,         None },
 	{ ControlMask,  XK_x,             g_prefix_external,    None },

--- a/main.c
+++ b/main.c
@@ -325,6 +325,10 @@ void load_image(int new)
 bool mark_image(int n, bool on)
 {
 	markidx = n;
+	if (options->dmenu) {
+		on = true;
+		printf("%s\n", files[n].name);
+	}
 	if (!!(files[n].flags & FF_MARK) != on) {
 		files[n].flags ^= FF_MARK;
 		markcnt += on ? 1 : -1;

--- a/nsxiv.1
+++ b/nsxiv.1
@@ -94,6 +94,12 @@ with
 .B \-i
 nsxiv can be used as a visual filter/pipe.
 .TP
+.B \-O
+Activate dmenu mode. Marking an image will immediately output it's name to
+standard output. Images cannot be unmarked in this mode. Reverse marking
+.RB ( Ctrl\-m )
+is also disabled.
+.TP
 .B \-p
 Enable private mode, in which nsxiv does not write any cache or temporary files.
 .TP

--- a/nsxiv.1
+++ b/nsxiv.1
@@ -136,6 +136,9 @@ Prefix the next command with a number (denoted via
 .B q
 Quit nsxiv.
 .TP
+.B Shift-Return
+Print the current filename to standard out and quit sxiv.
+.TP
 .B Return
 Switch to thumbnail mode / open selected image in image mode.
 .TP

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -267,6 +267,7 @@ struct opt {
 	/* file list: */
 	char **filenames;
 	bool from_stdin;
+	bool dmenu;
 	bool to_stdout;
 	bool recursive;
 	int filecnt;

--- a/options.c
+++ b/options.c
@@ -31,7 +31,7 @@ const opt_t *options = (const opt_t*) &_options;
 
 void print_usage(void)
 {
-	printf("usage: nsxiv [-abcfhiopqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
+	printf("usage: nsxiv [-abcfhiOopqrtvZ] [-A FRAMERATE] [-e WID] [-G GAMMA] "
 	       "[-g GEOMETRY] [-N NAME] [-T TITLE] [-n NUM] [-S DELAY] [-s MODE] "
 	       "[-z ZOOM] FILES...\n");
 }
@@ -51,6 +51,7 @@ void parse_options(int argc, char **argv)
 	progname = progname ? progname + 1 : argv[0];
 
 	_options.from_stdin = false;
+	_options.dmenu = false;
 	_options.to_stdout = false;
 	_options.recursive = false;
 	_options.startnum = 0;
@@ -75,7 +76,7 @@ void parse_options(int argc, char **argv)
 	_options.clean_cache = false;
 	_options.private_mode = false;
 
-	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:opqrS:s:T:tvZz:")) != -1) {
+	while ((opt = getopt(argc, argv, "A:abce:fG:g:hin:N:OopqrS:s:T:tvZz:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -127,6 +128,9 @@ void parse_options(int argc, char **argv)
 				break;
 			case 'N':
 				_options.res_name = optarg;
+				break;
+			case 'O':
+				_options.dmenu = true;
 				break;
 			case 'o':
 				_options.to_stdout = true;


### PR DESCRIPTION
Idea taken from https://github.com/muennich/sxiv/pull/405

I didn't think it would be good design to override a default keybinding to do something completely different depending on the mode. If someone presses `Enter` via muscle memory to switch mode it would end up selecting that img and quitting sxiv.

Having a separate binding (shift+enter) for printing to stdout and quitting seems more sane.