### PR TITLE
Reworked config.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CPPFLAGS = -D_XOPEN_SOURCE=700 \
 LDLIBS = -lImlib2 -lX11 -lXft -lfontconfig $(OPTIONAL_LIBS)
 
 OBJS = autoreload_$(AUTORELOAD).o commands.o image.o main.o options.o \
-  thumbs.o util.o window.o
+  thumbs.o util.o window.o $(EXTRA_OBJS)
 
 .PHONY: all clean install uninstall
 .SUFFIXES:
@@ -56,12 +56,13 @@ window.o: icon/data.h
 
 config.mk:
 	@echo "GEN $@"
-	@echo "# 0 = disable, 1 = enable" > config.mk
+	@echo "# 0 = disable, 1 = enable" > $@
 	@for lib in exif gif; do \
 		if echo "int main(){}" | $(CC) "-l$$lib" -o /dev/null -x c - 2>/dev/null ; then \
-			echo "HAVE_LIB$$lib=1" | tr '[:lower:]' '[:upper:]' >> config.mk ; \
+			echo "HAVE_LIB$$lib=1" | tr '[:lower:]' '[:upper:]' >> $@ ; \
 		fi \
 	done
+	[ -f config.c ] && echo EXTRA_OBJS += config.o >> $@ || true
 
 config.h:
 	@echo "GEN $@"

--- a/commands.c
+++ b/commands.c
@@ -17,7 +17,6 @@
  */
 
 #include "nsxiv.h"
-#define _IMAGE_CONFIG
 #include "config.h"
 
 #include <stdlib.h>

--- a/config.def.h
+++ b/config.def.h
@@ -1,8 +1,8 @@
 #ifdef _WINDOW_CONFIG
 
 /* default window dimensions (overwritten via -g option): */
-static const int WIN_WIDTH  = 800;
-static const int WIN_HEIGHT = 600;
+int WIN_WIDTH  = 800;
+int WIN_HEIGHT = 600;
 
 /* colors and font are configured with 'background', 'foreground' and
  * 'font' X resource properties.
@@ -13,14 +13,14 @@ static const int WIN_HEIGHT = 600;
 #ifdef _TITLE_CONFIG
 
 /* default title prefix */
-static const char *TITLE_PREFIX = "nsxiv - ";
+char *TITLE_PREFIX = "nsxiv - ";
 
 /* default title suffixmode, available options are:
  * SUFFIX_EMPTY
  * SUFFIX_BASENAME
  * SUFFIX_FULLPATH
  */
-static const suffixmode_t TITLE_SUFFIXMODE = SUFFIX_BASENAME;
+suffixmode_t TITLE_SUFFIXMODE = SUFFIX_BASENAME;
 
 #endif
 #ifdef _IMAGE_CONFIG
@@ -28,47 +28,47 @@ static const suffixmode_t TITLE_SUFFIXMODE = SUFFIX_BASENAME;
 /* levels (in percent) to use when zooming via '-' and '+':
  * (first/last value is used as min/max zoom level)
  */
-static const float zoom_levels[] = {
+float zoom_levels[] = {
 	 12.5,  25.0,  50.0,  75.0,
 	100.0, 150.0, 200.0, 400.0, 800.0
 };
 
 /* default slideshow delay (in sec, overwritten via -S option): */
-static const int SLIDESHOW_DELAY = 5;
+int SLIDESHOW_DELAY = 5;
 
 /* gamma correction: the user-visible ranges [-GAMMA_RANGE, 0] and
  * (0, GAMMA_RANGE] are mapped to the ranges [0, 1], and (1, GAMMA_MAX].
  * */
-static const double GAMMA_MAX   = 10.0;
-static const int    GAMMA_RANGE = 32;
+double GAMMA_MAX   = 10.0;
+int    GAMMA_RANGE = 32;
 
 /* command i_scroll pans image 1/PAN_FRACTION of screen width/height */
-static const int PAN_FRACTION = 5;
+int PAN_FRACTION = 5;
 
 /* if false, pixelate images at zoom level != 100%,
  * toggled with 'a' key binding
  */
-static const bool ANTI_ALIAS = true;
+bool ANTI_ALIAS = true;
 
 /* if true, use a checkerboard background for alpha layer,
  * toggled with 'A' key binding
  */
-static const bool ALPHA_LAYER = false;
+bool ALPHA_LAYER = false;
 
 #endif
 #ifdef _THUMBS_CONFIG
 
 /* thumbnail sizes in pixels (width == height): */
-static const int thumb_sizes[] = { 32, 64, 96, 128, 160 };
+int thumb_sizes[] = { 32, 64, 96, 128, 160 };
 
 /* thumbnail size at startup, index into thumb_sizes[]: */
-static const int THUMB_SIZE = 3;
+int THUMB_SIZE = 3;
 
 #endif
 #ifdef _MAPPINGS_CONFIG
 
 /* keyboard mappings for image and thumbnail mode: */
-static const keymap_t keys[] = {
+keymap_t keys[] = {
 	/* modifiers    key               function              argument */
 	{ 0,            XK_q,             g_quit,               None },
 	{ 0,            XK_Return,        g_switch_mode,        None },
@@ -153,7 +153,7 @@ static const keymap_t keys[] = {
 };
 
 /* mouse button mappings for image mode: */
-static const button_t buttons[] = {
+button_t buttons[] = {
 	/* modifiers    button            function              argument */
 	{ 0,            1,                i_cursor_navigate,    None },
 	{ 0,            2,                i_drag,               DRAG_ABSOLUTE },

--- a/options.c
+++ b/options.c
@@ -17,7 +17,6 @@
  */
 
 #include "nsxiv.h"
-#define _IMAGE_CONFIG
 #define _TITLE_CONFIG
 #include "config.h"
 #include "version.h"


### PR DESCRIPTION
Restructured config.c so that new features won't break existing configs
(after this commit)

config.h can now only include settings the user wants to override
instead of everything.

Closes #36

For those that weren't following the issue, the problem this fixes, is that the introduction of any new config options breaks all existing configs.

Some notes
- In my opinion the biggest downside to this patch is that introduction to config_defs.h that has config declarations. We could auto generate this from config.def.h if we felt like it
- Feel free to standardize variable naming.
- This does involve breaking existing configs.
- This doesn't allows users wanting to add/remove a specific keybinding without defining all of them. Can do that in a separate patch.
- If you want you config file to break everything a new option was added, we can have some config version you could check against.
- This is not intended to support dynamic configuration and as such as new use to binary distro users.