### PR TITLE
add .mark.foreground to Xresources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ nsxiv
   * Fill scale mode (#2)
   * Configurable X window title (via `config.h` and the `-T` flag) (#23)
   * Support custom bar colors via Xresources (#19)
+  * Support custom mark color via Xresources (#51)
   * Toggle animation playback with <kbd>Ctrl-a</kbd> (#33)
   * Set `_NET_WM_PID` and `WM_CLIENT_MACHINE` X properties (#13)
   * Set `ICCCM WM manager` hints (#12)

--- a/nsxiv.1
+++ b/nsxiv.1
@@ -402,14 +402,17 @@ Color of the window background
 .B window.foreground
 Color of the window foreground
 .TP
+.B bar.font
+Name of Xft bar font
+.TP
 .B bar.background
 Color of the bar background. Defaults to window.foreground
 .TP
 .B bar.foreground
 Color of the bar foreground. Defaults to window.background
 .TP
-.B bar.font
-Name of Xft bar font
+.B mark.foreground
+Color of the mark foreground. Defaults to window.foreground
 .TP
 Please see xrdb(1) on how to change them.
 .SH STATUS BAR

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -421,6 +421,7 @@ struct win {
 	XftColor win_fg;
 	XftColor bar_bg;
 	XftColor bar_fg;
+	XftColor mrk_fg;
 
 	int x;
 	int y;

--- a/thumbs.c
+++ b/thumbs.c
@@ -478,7 +478,7 @@ void tns_mark(tns_t *tns, int n, bool mark)
 		win_draw_rect(win, x + 1, y - 1, tns->bw, 1, true, 1, col);
 
 		if (mark)
-			col = win->win_fg.pixel;
+			col = win->mrk_fg.pixel;
 
 		win_draw_rect(win, x, y, tns->bw + 2, tns->bw + 2, true, 1, col);
 

--- a/window.c
+++ b/window.c
@@ -94,7 +94,7 @@ const char* win_res(XrmDatabase db, const char *name, const char *def)
 void win_init(win_t *win)
 {
 	win_env_t *e;
-	const char *win_bg, *win_fg, *bar_bg, *bar_fg, *f;
+	const char *win_bg, *win_fg, *bar_bg, *bar_fg, *mrk_fg, *f;
 	char *res_man;
 	XrmDatabase db;
 	XVisualInfo vis;
@@ -138,10 +138,12 @@ void win_init(win_t *win)
 	win_fg = win_res(db, RES_CLASS ".window.foreground", "black");
 	bar_bg = win_res(db, RES_CLASS ".bar.background", win_bg);
 	bar_fg = win_res(db, RES_CLASS ".bar.foreground", win_fg);
+	mrk_fg = win_res(db, RES_CLASS ".mark.foreground", win_fg);
 	win_alloc_color(e, win_bg, &win->win_bg);
 	win_alloc_color(e, win_fg, &win->win_fg);
 	win_alloc_color(e, bar_bg, &win->bar_bg);
 	win_alloc_color(e, bar_fg, &win->bar_fg);
+	win_alloc_color(e, mrk_fg, &win->mrk_fg);
 
 	win->bar.l.size = BAR_L_LEN;
 	win->bar.r.size = BAR_R_LEN;


### PR DESCRIPTION
since we're already allowing both window and bar colors to be
customizable it doesn't make sense to not allow so for mark color.