### PR TITLE
Exit when window is destroyed

### DIFF
--- a/main.c
+++ b/main.c
@@ -767,6 +767,9 @@ void run(void)
 				if ((Atom) ev.xclient.data.l[0] == atoms[ATOM_WM_DELETE_WINDOW])
 					cmds[g_quit].func(0);
 				break;
+			case DestroyNotify:
+				exit(EXIT_FAILURE);
+				break;
 			case ConfigureNotify:
 				if (win_configure(&win, &ev.xconfigure)) {
 					if (mode == MODE_IMAGE) {


### PR DESCRIPTION
If the user closed our window, the program won't automatically be die.
It may look dead as there would be no graphical indication that it was
running, but it still would be using/wasting the same resources.
Now the program will abruptly exit when its window is killed.

Note that forcibly destroying the window is different than sending the WM_DELETE_WINDOW request or forcibly closing the connection. We handled those cases fine.

Choose to exit with status 1 instead of 0 because don't consider this a normal case. Don't have a strong opinion on the matter