### PR TITLE
Fix README image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![sxiv](http://muennich.github.com/sxiv/img/logo.png "sxiv")
+![sxiv](https://raw.githubusercontent.com/nsxiv/nsxiv/gh-pages/img/logo.png "sxiv")
 
 **Simple X Image Viewer**
 
@@ -25,11 +25,11 @@ Screenshots
 
 **Image mode:**
 
-![Image](http://muennich.github.com/sxiv/img/image.png "Image mode")
+![Image](https://raw.githubusercontent.com/nsxiv/nsxiv/gh-pages/img/image.png "Image mode")
 
 **Thumbnail mode:**
 
-![Thumb](http://muennich.github.com/sxiv/img/thumb.png "Thumb mode")
+![Thumb](https://raw.githubusercontent.com/nsxiv/nsxiv/gh-pages/img/thumb.png "Thumb mode")
 
 
 Dependencies


### PR DESCRIPTION
The links for the images (logo, image, thumb) in the README lead nowhere. This change links them to the gh-pages branch, so the images actually show up.