### PR TITLE
Fix font memory leak.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Fixes:
   * Wrong keybinding description in the manpage (#14)
   * .desktop entry not advertising webp support (#15)
   * Prevent crash when embedded into transparent window (#3)
+  * Small memory leak (#57)
   * Rare crash when showing some GIFs (#41)
   * Rare event when nsxiv wouldn't close after window being destroyed (#53)
 

--- a/window.c
+++ b/window.c
@@ -61,6 +61,7 @@ void win_init_font(const win_env_t *e, const char *fontstr)
 	fontheight = font->ascent + font->descent;
 	FcPatternGetDouble(font->pattern, FC_SIZE, 0, &fontsize);
 	barheight = fontheight + 2 * V_TEXT_PAD;
+	XftFontClose(e->dpy, font);
 }
 
 void win_alloc_color(const win_env_t *e, const char *name, XftColor *col)


### PR DESCRIPTION
This memory leak has always been present in sxiv.

The font opened on window.c:58 was never closed, so I closed it, fixing a 2kB memory leak (2497 bytes).