### PR TITLE
fix build when .git/index doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ version.h: Makefile .git/index
 	v="$$(git describe 2>/dev/null)"; \
 	echo "#define VERSION \"$${v:-$(VERSION)}\"" >$@
 
+.git/index:
+
 clean:
 	$(RM) *.o nsxiv
 


### PR DESCRIPTION
Currently our build fails on `version.h` if there is no `.git/index` 