### PR TITLE
fix: crashing on bad exif thumbnail

### DIFF
--- a/thumbs.c
+++ b/thumbs.c
@@ -312,7 +312,7 @@ bool tns_load(tns_t *tns, int n, bool force, bool cache_only)
 						}
 						if (w >= maxwh || h >= maxwh) {
 							if ((im = imlib_create_cropped_image(x, y, w, h)) == NULL)
-								error(0, 0, "error generating thumbnail: %s", file->name);
+								error(0, 0, "%s: error generating thumbnail", file->name);
 						}
 						imlib_free_image_and_decache();
 					}

--- a/thumbs.c
+++ b/thumbs.c
@@ -312,7 +312,7 @@ bool tns_load(tns_t *tns, int n, bool force, bool cache_only)
 						}
 						if (w >= maxwh || h >= maxwh) {
 							if ((im = imlib_create_cropped_image(x, y, w, h)) == NULL)
-								error(0, 0, "Bad exif data: %s", file->name);
+								error(0, 0, "error generating thumbnail: %s", file->name);
 						}
 						imlib_free_image_and_decache();
 					}

--- a/thumbs.c
+++ b/thumbs.c
@@ -312,7 +312,7 @@ bool tns_load(tns_t *tns, int n, bool force, bool cache_only)
 						}
 						if (w >= maxwh || h >= maxwh) {
 							if ((im = imlib_create_cropped_image(x, y, w, h)) == NULL)
-								error(EXIT_FAILURE, ENOMEM, NULL);
+								error(0, 0, "Bad exif data: %s", file->name);
 						}
 						imlib_free_image_and_decache();
 					}


### PR DESCRIPTION
this does not need to be a fatal error.
if im is NULL we're going to load it with imlib2 anyways.

one other problem this solves is that before, due to the fatal error,
the tmpfile opened under /tmp wouldn't get cleaned up.

Closes: https://github.com/nsxiv/nsxiv/issues/69