### PR TITLE
Allow any set of modifiers to be used in keybindings 

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -67,7 +67,7 @@ static const int THUMB_SIZE = 3;
 #endif
 #ifdef _MAPPINGS_CONFIG
 
-/* Bitmask of modifiers whose presence in key events/keybindings are ignored */
+/* Following modifiers (NumLock | CapsLock) will be ignored when processing keybindings */
 static const int ignore_mask = Mod2Mask | LockMask;
 
 /* keyboard mappings for image and thumbnail mode: */

--- a/config.def.h
+++ b/config.def.h
@@ -67,8 +67,9 @@ static const int THUMB_SIZE = 3;
 #endif
 #ifdef _MAPPINGS_CONFIG
 
-/* Ignore NumLock modifier for keybindings */
-static const int filter_mask = Mod2Mask;
+/* Bitmask of modifiers whose presence in key events/keybindings are ignored */
+static const int ignore_mask = Mod2Mask | LockMask;
+
 /* keyboard mappings for image and thumbnail mode: */
 static const keymap_t keys[] = {
 	/* modifiers    key               function              argument */

--- a/config.def.h
+++ b/config.def.h
@@ -67,6 +67,8 @@ static const int THUMB_SIZE = 3;
 #endif
 #ifdef _MAPPINGS_CONFIG
 
+/* Ignore NumLock modifier for keybindings */
+static const int filter_mask = Mod2Mask;
 /* keyboard mappings for image and thumbnail mode: */
 static const keymap_t keys[] = {
 	/* modifiers    key               function              argument */

--- a/main.c
+++ b/main.c
@@ -566,7 +566,7 @@ end:
 	redraw();
 }
 
-#define MODMASK(mask) ((mask) & (~filter_mask))
+#define MODMASK(mask) ((mask) & (~ignore_mask))
 
 void on_keypress(XKeyEvent *kev)
 {

--- a/main.c
+++ b/main.c
@@ -566,7 +566,7 @@ end:
 	redraw();
 }
 
-#define MODMASK(mask) ((mask) & (~ignore_mask))
+#define MODMASK(mask) ((mask) & ~ignore_mask)
 
 void on_keypress(XKeyEvent *kev)
 {

--- a/main.c
+++ b/main.c
@@ -566,7 +566,7 @@ end:
 	redraw();
 }
 
-#define MODMASK(mask) ((mask) & (ShiftMask|ControlMask|Mod1Mask))
+#define MODMASK(mask) ((mask) & (~filter_mask))
 
 void on_keypress(XKeyEvent *kev)
 {


### PR DESCRIPTION
Previous the code only allowed ShiftMask, ControlMask or Mod1Mask to be
used in keybindings and the presence of any others modifiers would be
ignored. Most problems generally allow certain modifiers to be be
ignored but not most and certainly don't allow Super-A to be treated
like A.
Now users can use any modifiers they want in keybindings and can also
ignore any modifiers they want. By default only ModMask2 (commonly
numlock is ignored)