### PR TITLE
code-style: use constant length array

### DIFF
--- a/window.c
+++ b/window.c
@@ -493,7 +493,7 @@ void win_draw_rect(win_t *win, int x, int y, int w, int h, bool fill, int lw,
 
 void win_set_title(win_t *win, const char *path)
 {
-	const unsigned int title_max = strlen(path) + strlen(options->title_prefix) + 1;
+	enum { title_max = 512 };
 	char title[title_max];
 	const char *basename = strrchr(path, '/') + 1;
 


### PR DESCRIPTION
currently the code-base doesn't make use of variable length array
despite being -std=c99. it was irresponsible of me to introduce VLA in
here.

since this function will be called quite often, i did not want to make
calls to malloc and free as they have some overhead.

512 should be sufficient enough and probably is far bigger than any
window title bar can display anyways.

- - -

* Should we add `-Wvla` to `CFLAGS` to prevent accidentally adding vla in the future?
* Is my assumption that 512 chars is bigger than most wm title bar can display wrong?