### PR TITLE
better document what the optional deps do

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ nsxiv requires the following software to be installed:
   * Xft
   * freetype2
   * fontconfig
-  * giflib (optional, automatically enabled if installed)
-  * libexif (optional, automatically enabled if installed)
+
+The following libraries are optional. They are automatically enabled if installed.
+
+  * giflib : Used for animated gif playback.
+  * libexif : Used for auto-orientation and exif thumbnails.
 
 Please make sure to install the corresponding development packages in case that
 you want to build nsxiv on a distribution with separate runtime and development


### PR DESCRIPTION
currently the README only mentions what deps are optional but has no
info on what they do. we had an issue where a user was confused about
what libexif is used for : https://github.com/nsxiv/nsxiv/issues/58

this makes it clear what each of the optional deps do so that users can
make more informed decision on weather they want something or not.