### PR TITLE
Clarify comment in example key-handler

### DIFF
--- a/examples/key-handler
+++ b/examples/key-handler
@@ -11,6 +11,8 @@
 # The key combo argument has the following form: "[C-][M-][S-]KEY",
 # where C/M/S indicate Ctrl/Meta(Alt)/Shift modifier states and KEY is the X
 # keysym as listed in /usr/include/X11/keysymdef.h without the "XK_" prefix.
+# If KEY has an uppercase equivalent, S-KEY is resolved into it. For instance,
+# K replaces S-k and Scedilla replaces S-scedilla, but S-Delete is sent as-is.
 
 rotate() {
 	degree="$1"

--- a/examples/key-handler
+++ b/examples/key-handler
@@ -8,10 +8,9 @@
 # nsxiv(1) blocks until this script terminates. It then checks which images
 # have been modified and reloads them.
 
-# The key combo argument has the following form: "[C-][M-]KEY", where C/M
-# indicate Ctrl/Meta(Alt) modifier states and KEY is the X keysym as listed in
-# /usr/include/X11/keysymdef.h without the "XK_" prefix. In the case of
-# Shift+KEY, the capital letter will be sent.
+# The key combo argument has the following form: "[C-][M-][S-]KEY",
+# where C/M/S indicate Ctrl/Meta(Alt)/Shift modifier states and KEY is the X
+# keysym as listed in /usr/include/X11/keysymdef.h without the "XK_" prefix.
 
 rotate() {
 	degree="$1"

--- a/examples/key-handler
+++ b/examples/key-handler
@@ -8,9 +8,10 @@
 # nsxiv(1) blocks until this script terminates. It then checks which images
 # have been modified and reloads them.
 
-# The key combo argument has the following form: "[C-][M-][S-]KEY",
-# where C/M/S indicate Ctrl/Meta(Alt)/Shift modifier states and KEY is the X
-# keysym as listed in /usr/include/X11/keysymdef.h without the "XK_" prefix.
+# The key combo argument has the following form: "[C-][M-]KEY", where C/M
+# indicate Ctrl/Meta(Alt) modifier states and KEY is the X keysym as listed in
+# /usr/include/X11/keysymdef.h without the "XK_" prefix. In the case of
+# Shift+KEY, the capital letter will be sent.
 
 rotate() {
 	degree="$1"


### PR DESCRIPTION
currently, the key-handler will never recieve the `S-` modifier. if
https://github.com/nsxiv/nsxiv/pull/78 is to be merged, then this
behaviour may change.

however as it currently stands, we should fix the comment. we can update
it later if needed.