### PR TITLE
Fix consistency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ Installing icons:
     # make icon
 
 Please note, that these requires root privileges.
-By default, nsxiv is installed using the prefix "/usr/local", so the full path
-of the executable will be "/usr/local/bin/nsxiv", the `.desktop` entry will be
-"/usr/local/share/applications/nsxiv.desktop" and the icon path will be
-"/usr/local/share/icons/hicolor/{size}/apps/nsxiv.png".
+By default, nsxiv is installed using the prefix `/usr/local`, so the full path
+of the executable will be `/usr/local/bin/nsxiv`, the `.desktop` entry will be
+`/usr/local/share/applications/nsxiv.desktop` and the icon path will be
+`/usr/local/share/icons/hicolor/{size}/apps/nsxiv.png`.
 
 You can install nsxiv into a directory of your choice by changing this command to:
 


### PR DESCRIPTION
Some paths use \`, whereas others use ". Now, all of them use \`.