### PR TITLE
add statusbar info on getting keyhandler input

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -37,6 +37,7 @@ void animate(void);
 void slideshow(void);
 void set_timeout(timeout_f, int, bool);
 void reset_timeout(timeout_f);
+void init_key_handler(void);
 
 extern appmode_t mode;
 extern img_t img;
@@ -114,7 +115,7 @@ bool cg_toggle_bar(arg_t _)
 
 bool cg_prefix_external(arg_t _)
 {
-	extprefix = true;
+	init_key_handler();
 	return false;
 }
 

--- a/main.c
+++ b/main.c
@@ -469,6 +469,15 @@ Bool is_input_ev(Display *dpy, XEvent *ev, XPointer arg)
 	return ev->type == ButtonPress || ev->type == KeyPress;
 }
 
+void init_key_handler(void)
+{
+	extprefix = true;
+	close_info();
+	snprintf(win.bar.l.buf, win.bar.l.size, "Getting key handler input "
+	         "(%s to abort)...", XKeysymToString(keyhandler_abort));
+	win_draw(&win);
+}
+
 void run_key_handler(const char *key, unsigned int mask)
 {
 	pid_t pid;
@@ -588,6 +597,8 @@ void on_keypress(XKeyEvent *kev)
 	if (IsModifierKey(ksym))
 		return;
 	if (extprefix && ksym == keyhandler_abort && MODMASK(kev->state) == 0) {
+		open_info();
+		redraw();
 		extprefix = False;
 	} else if (extprefix) {
 		run_key_handler(XKeysymToString(ksym), kev->state & ~sh);


### PR DESCRIPTION
Currently when running the key-handler the statusbar shows a "Running key-handler..." message, but there's no indication of the prefix key being pressed. There's a slight functional benefit of this patch in the sense that users can visually tell if the key-handler is listening on input or if the key-handler has been aborted or not.

- - -

Since I'm not too sure weather this gets into mainline nsxiv or not, I didn't properly verify for any side-effects.