### PR TITLE
make ten_ms local to run

### DIFF
--- a/main.c
+++ b/main.c
@@ -682,13 +682,12 @@ void on_buttonpress(XButtonEvent *bev)
 	prefix = 0;
 }
 
-const struct timespec ten_ms = {0, 10000000};
-
 void run(void)
 {
 	int xfd;
 	fd_set fds;
 	struct timeval timeout;
+	const struct timespec ten_ms = {0, 10000000};
 	bool discard, init_thumb, load_thumb, to_set;
 	XEvent ev, nextev;
 


### PR DESCRIPTION
ten_ms needed to be a global but after the following commit
3724d3fc17dc6135a05608cab5bdf00c6978282d this no longer holds true.
it can simply be local to run, as it's not used anywhere else.