### PR TITLE
Add colors and fonts to config.h

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -4,9 +4,17 @@
 static const int WIN_WIDTH  = 800;
 static const int WIN_HEIGHT = 600;
 
-/* colors and font are configured via X resource properties.
+/* colors and font can be overwritten via X resource properties.
  * See nsxiv(1), X(7) section Resources and xrdb(1) for more information.
  */
+static const char *DEFAULT_WIN_BG     = "white";
+static const char *DEFAULT_WIN_FG     = "black";
+static const char *DEFAULT_MARK_COLOR = NULL;  /* NULL means it will default to window foreground */
+#if HAVE_LIBFONTS
+static const char *DEFAULT_BAR_BG     = NULL;  /* NULL means it will default to window background */
+static const char *DEFAULT_BAR_FG     = NULL;  /* NULL means it will default to window foreground */
+static const char *DEFAULT_FONT       = "monospace-8";
+#endif
 
 #endif
 #ifdef _TITLE_CONFIG

--- a/window.c
+++ b/window.c
@@ -144,20 +144,20 @@ void win_init(win_t *win)
 	res_man = XResourceManagerString(e->dpy);
 	db = res_man != NULL ? XrmGetStringDatabase(res_man) : None;
 
-	win_bg = win_res(db, RES_CLASS ".window.background", "white");
-	win_fg = win_res(db, RES_CLASS ".window.foreground", "black");
-	mrk_fg = win_res(db, RES_CLASS ".mark.foreground", win_fg);
+	win_bg = win_res(db, RES_CLASS ".window.background", DEFAULT_WIN_BG);
+	win_fg = win_res(db, RES_CLASS ".window.foreground", DEFAULT_WIN_FG);
+	mrk_fg = win_res(db, RES_CLASS ".mark.foreground",   DEFAULT_MARK_COLOR ? DEFAULT_MARK_COLOR : win_fg);
 	win_alloc_color(e, win_bg, &win->win_bg);
 	win_alloc_color(e, win_fg, &win->win_fg);
 	win_alloc_color(e, mrk_fg, &win->mrk_fg);
 
 #if HAVE_LIBFONTS
-	bar_bg = win_res(db, RES_CLASS ".bar.background", win_bg);
-	bar_fg = win_res(db, RES_CLASS ".bar.foreground", win_fg);
+	bar_bg = win_res(db, RES_CLASS ".bar.background", DEFAULT_BAR_BG ? DEFAULT_BAR_BG : win_bg);
+	bar_fg = win_res(db, RES_CLASS ".bar.foreground", DEFAULT_BAR_FG ? DEFAULT_BAR_FG : win_fg);
 	xft_alloc_color(e, bar_bg, &win->bar_bg);
 	xft_alloc_color(e, bar_fg, &win->bar_fg);
 
-	f = win_res(db, RES_CLASS ".bar.font", "monospace-8");
+	f = win_res(db, RES_CLASS ".bar.font", DEFAULT_FONT);
 	win_init_font(e, f);
 
 	win->bar.l.size = BAR_L_LEN;


### PR DESCRIPTION
Adds a set of config vars to controll window fg/bg, bar fg/bg and mark
color. This allows everything that can be done from .Xresources to be
configurable from config.h

This was originally part of #95, but moved to its own PR by request.