### PR TITLE
Revert "Fix in tabbed with alpha patch (#3)"

### DIFF
--- a/image.c
+++ b/image.c
@@ -627,7 +627,7 @@ void img_render(img_t *img)
 		if ((bg = imlib_create_image(dw, dh)) == NULL)
 			error(EXIT_FAILURE, ENOMEM, NULL);
 		imlib_context_set_image(bg);
-		imlib_image_set_has_alpha(1);
+		imlib_image_set_has_alpha(0);
 
 		if (img->alpha) {
 			int i, c, r;
@@ -655,7 +655,6 @@ void img_render(img_t *img)
 		imlib_free_image();
 		imlib_context_set_color_modifier(img->cmod);
 	} else {
-		imlib_image_set_has_alpha(1);
 		imlib_render_image_part_on_drawable_at_size(sx, sy, sw, sh, dx, dy, dw, dh);
 	}
 	img->dirty = false;


### PR DESCRIPTION
This reverts commit c7ca547b55e98914264351502e581fe6ae17ae15.

cd710f5 fixed the issue with embedding into a parent that has alpha and
partially reverted c7ca547

this commit fully reverts c7ca547 , as these changes aren't needed for
embedding into an alpha-parent.