### PR TITLE
include config.h after all declarations

### DIFF
--- a/main.c
+++ b/main.c
@@ -18,8 +18,6 @@
 
 #include "nsxiv.h"
 #include "commands.h"
-#define _MAPPINGS_CONFIG
-#include "config.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -92,6 +90,10 @@ timeout_t timeouts[] = {
 	{ { 0, 0 }, false, slideshow    },
 	{ { 0, 0 }, false, clear_resize },
 };
+
+/* configuration, allows nested code to access above variables */
+#define _MAPPINGS_CONFIG
+#include "config.h"
 
 /**************************
   function implementations


### PR DESCRIPTION
in dwm \[0] as well as dmenu \[1] config.h is included after all
declarations so that nested code can access those variables.
since we've changed how keybindings are handled in 12efa0e , allowing
users to write functions inside config.h, it makes sense to move the
config.h to be #included at the bottom.

\[0]: https://git.suckless.org/dwm/file/dwm.c.html#l272
\[1]: https://git.suckless.org/dmenu/file/dmenu.c.html#l56