### PR TITLE
eleminate padding from struct img on 64bit systems

### DIFF
--- a/nsxiv.h
+++ b/nsxiv.h
@@ -209,6 +209,9 @@ struct img {
 	float x;
 	float y;
 
+	Imlib_Color_Modifier cmod;
+	int gamma;
+
 	scalemode_t scalemode;
 	float zoom;
 
@@ -216,9 +219,6 @@ struct img {
 	bool dirty;
 	bool aa;
 	bool alpha;
-
-	Imlib_Color_Modifier cmod;
-	int gamma;
 
 	struct {
 		bool on;


### PR DESCRIPTION
on 64bit systems this reduces the size of the struct from 104 bytes down
to 96 bytes.

on 32bits system this change shouldn't have any affect.