### PR TITLE
apply -0 to key-handler as well

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -60,7 +60,7 @@ bool cg_quit(arg_t _)
 	if (options->to_stdout && markcnt > 0) {
 		for (i = 0; i < filecnt; i++) {
 			if (files[i].flags & FF_MARK)
-				printf("%s%c", files[i].name, options->stdout_separator);
+				printf("%s%c", files[i].name, options->using_null ? '\0' : '\n');
 		}
 	}
 	exit(EXIT_SUCCESS);

--- a/main.c
+++ b/main.c
@@ -545,7 +545,7 @@ void run_key_handler(const char *key, unsigned int mask)
 	for (f = i = 0; f < fcnt; i++) {
 		if ((marked && (files[i].flags & FF_MARK)) || (!marked && i == fileidx)) {
 			stat(files[i].path, &oldst[f]);
-			fprintf(pfs, "%s\n", files[i].name);
+			fprintf(pfs, "%s%c", files[i].name, options->using_null ? '\0' : '\n');
 			f++;
 		}
 	}

--- a/nsxiv.1
+++ b/nsxiv.1
@@ -127,8 +127,8 @@ The same as `\-z 100'.
 Set zoom level to ZOOM percent.
 .TP
 .B \-0
-Same as \-o, however the marked files are NULL separated. This option implies
-\-o.
+Use NULL-separator. With this option output of \-o and file-list sent to the
+key-handler will be seperated by a NULL character.
 .SH KEYBOARD COMMANDS
 .SS General
 The following keyboard commands are available in both image and thumbnail mode:

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -255,7 +255,7 @@ struct opt {
 	char **filenames;
 	bool from_stdin;
 	bool to_stdout;
-	char stdout_separator;
+	bool using_null;
 	bool recursive;
 	int filecnt;
 	int startnum;

--- a/options.c
+++ b/options.c
@@ -52,7 +52,7 @@ void parse_options(int argc, char **argv)
 
 	_options.from_stdin = false;
 	_options.to_stdout = false;
-	_options.stdout_separator = '\n';
+	_options.using_null = false;
 	_options.recursive = false;
 	_options.startnum = 0;
 
@@ -181,8 +181,7 @@ void parse_options(int argc, char **argv)
 				_options.zoom = (float) n / 100.0;
 				break;
 			case '0':
-				_options.stdout_separator = '\0';
-				_options.to_stdout = true;  /* -0 implies -o */
+				_options.using_null = true;
 				break;
 		}
 	}


### PR DESCRIPTION
with this change `-0` is turned into a more generic switch which can be
used to send NULL-separated file-list to the key-handler as well.
this also means `-0` no longer implicitly enables `-o`

Closes: https://github.com/nsxiv/nsxiv/issues/140