### PR TITLE
remove unnecessary animated webp related check

### DIFF
--- a/image.c
+++ b/image.c
@@ -445,13 +445,7 @@ Imlib_Image img_open(const fileinfo_t *file)
 			im = imlib_load_image(file->path);
 		if (im != NULL) {
 			imlib_context_set_image(im);
-#if HAVE_LIBWEBP
-			const char *fmt;
-			if ((fmt = imlib_image_format()) != NULL && !STREQ(fmt, "webp") &&
-			    imlib_image_get_data_for_reading_only() == NULL) {
-#else
 			if (imlib_image_get_data_for_reading_only() == NULL) {
-#endif
 				imlib_free_image();
 				im = NULL;
 			}


### PR DESCRIPTION
this code snippet was introduced in
https://github.com/nsxiv/nsxiv/pull/20/commits/2703809a23bdf3fe426466c7a10f41d747913128
but does not seem to be needed.

from what i can tell this is some sort of hack that might've been needed
when we didn't bypass imlib2 when loading webp.