### PR TITLE
Stop special casing prefix and keyhandlers

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -328,6 +328,10 @@ bool ci_scroll_to_edge(arg_t dir)
 	return img_pan_edge(&img, dir);
 }
 
+bool ci_navigate_and_reset_scroll(arg_t dir) {
+    return ci_navigate(dir) && ci_scroll_to_edge(DIR_LEFT | DIR_UP);
+}
+
 bool ci_drag(arg_t mode)
 {
 	int x, y, ox, oy;

--- a/commands.h
+++ b/commands.h
@@ -3,12 +3,13 @@
 #include <stdbool.h>
 
 /* global */
+bool cg_run_key_handler();
 bool cg_change_gamma();
 bool cg_first();
+bool cg_key_handler();
 bool cg_mark_range();
 bool cg_n_or_last();
 bool cg_navigate_marked();
-bool cg_prefix_external();
 bool cg_quit();
 bool cg_reload_image();
 bool cg_remove_image();
@@ -42,12 +43,14 @@ bool ct_move_sel();
 bool ct_reload_all();
 
 /* global */
+#define g_run_key_handler { cg_run_key_handler, MODE_ALL }
+
 #define g_change_gamma { cg_change_gamma, MODE_ALL }
 #define g_first { cg_first, MODE_ALL }
 #define g_mark_range { cg_mark_range, MODE_ALL }
 #define g_n_or_last { cg_n_or_last, MODE_ALL }
 #define g_navigate_marked { cg_navigate_marked, MODE_ALL }
-#define g_prefix_external { cg_prefix_external, MODE_ALL }
+#define g_key_handler { cg_key_handler, MODE_ALL }
 #define g_quit { cg_quit, MODE_ALL }
 #define g_reload_image { cg_reload_image, MODE_ALL }
 #define g_remove_image { cg_remove_image, MODE_ALL }

--- a/commands.h
+++ b/commands.h
@@ -27,6 +27,7 @@ bool ci_drag();
 bool ci_fit_to_win();
 bool ci_flip();
 bool ci_navigate();
+bool ci_navigate_and_reset_scroll();
 bool ci_navigate_frame();
 bool ci_rotate();
 bool ci_scroll();
@@ -66,6 +67,7 @@ bool ct_reload_all();
 #define i_fit_to_win { ci_fit_to_win, MODE_IMAGE }
 #define i_flip { ci_flip, MODE_IMAGE }
 #define i_navigate { ci_navigate, MODE_IMAGE }
+#define i_navigate_and_reset_scroll { ci_navigate_and_reset_scroll, MODE_IMAGE }
 #define i_navigate_frame { ci_navigate_frame, MODE_IMAGE }
 #define i_rotate { ci_rotate, MODE_IMAGE }
 #define i_scroll { ci_scroll, MODE_IMAGE }

--- a/config.def.h
+++ b/config.def.h
@@ -121,11 +121,9 @@ static const keymap_t keys[] = {
 	{ 0,            XK_Right,         t_move_sel,           DIR_RIGHT },
 	{ 0,            XK_R,             t_reload_all,         None },
 
-	{ 0,            XK_n,             i_navigate,           +1 },
-	{ 0,            XK_n,             i_scroll_to_edge,     DIR_LEFT | DIR_UP },
+	{ 0,            XK_n,             i_navigate_and_reset_scroll,           +1},
+	{ 0,            XK_p,             i_navigate_and_reset_scroll,           -1},
 	{ 0,            XK_space,         i_navigate,           +1 },
-	{ 0,            XK_p,             i_navigate,           -1 },
-	{ 0,            XK_p,             i_scroll_to_edge,     DIR_LEFT | DIR_UP },
 	{ 0,            XK_BackSpace,     i_navigate,           -1 },
 	{ 0,            XK_bracketright,  i_navigate,           +10 },
 	{ 0,            XK_bracketleft,   i_navigate,           -10 },

--- a/config.def.h
+++ b/config.def.h
@@ -76,10 +76,10 @@ static const int ignore_mask = Mod2Mask | LockMask;
 
 /* keyboard mappings for image and thumbnail mode: */
 static const keymap_t keys[] = {
-	// Legacy keyhander related bindings
-	{ 0,			XK_Escape,		  g_key_handler,		false },
-	{ AnyModifier,	0,				  g_run_key_handler,	None, .enabled=&key_handler_enabled},
-	{ ControlMask,	XK_x,			  g_key_handler,		true  },
+	// Legacy key handler related bindings
+	{ 0,            XK_Escape,        g_key_handler,        false },
+	{ AnyModifier,  0,                g_run_key_handler,    None, .enabled=&key_handler_enabled},
+	{ ControlMask,  XK_x,             g_key_handler,        true  },
 
 	/* modifiers    key               function              argument */
 	{ 0,            XK_q,             g_quit,               None },

--- a/config.def.h
+++ b/config.def.h
@@ -74,17 +74,18 @@ static const int THUMB_SIZE = 3;
 /* following modifiers (NumLock | CapsLock) will be ignored when processing keybindings */
 static const int ignore_mask = Mod2Mask | LockMask;
 
-/* abort the keyhandler */
-static const KeySym keyhandler_abort = XK_Escape;
-
 /* keyboard mappings for image and thumbnail mode: */
 static const keymap_t keys[] = {
+	// Legacy keyhander related bindings
+	{ 0,			XK_Escape,		  g_key_handler,		false },
+	{ AnyModifier,	0,				  g_run_key_handler,	None, .enabled=&key_handler_enabled},
+	{ ControlMask,	XK_x,			  g_key_handler,		true  },
+
 	/* modifiers    key               function              argument */
 	{ 0,            XK_q,             g_quit,               None },
 	{ 0,            XK_Return,        g_switch_mode,        None },
 	{ 0,            XK_f,             g_toggle_fullscreen,  None },
 	{ 0,            XK_b,             g_toggle_bar,         None },
-	{ ControlMask,  XK_x,             g_prefix_external,    None },
 	{ 0,            XK_g,             g_first,              None },
 	{ 0,            XK_G,             g_n_or_last,          None },
 	{ 0,            XK_r,             g_reload_image,       None },

--- a/main.c
+++ b/main.c
@@ -637,12 +637,14 @@ void on_keypress(XKeyEvent *kev)
 	} else if (extprefix) {
 		run_key_handler(XKeysymToString(ksym), kev->state & ~sh);
 		extprefix = false;
-	} else if (key >= '0' && key <= '9') {
-		/* number prefix for commands */
-		prefix = prefix * 10 + (int) (key - '0');
-		return;
 	} else {
-		process_bindings(keys, ARRLEN(keys), ksym, kev->state, sh, &dirty);
+		if(!process_bindings(keys, ARRLEN(keys), ksym, kev->state, sh, &dirty)) {
+			if (key >= '0' && key <= '9') {
+				/* number prefix for commands */
+				prefix = prefix * 10 + (int) (key - '0');
+				return;
+			}
+		}
 	}
 	if (dirty)
 		redraw();

--- a/main.c
+++ b/main.c
@@ -69,6 +69,8 @@ bool extprefix;
 
 bool resized = false;
 
+XEvent ev;
+
 typedef struct {
 	int err;
 	char *cmd;
@@ -715,7 +717,7 @@ void run(void)
 	struct timeval timeout;
 	const struct timespec ten_ms = {0, 10000000};
 	bool discard, init_thumb, load_thumb, to_set;
-	XEvent ev, nextev;
+	XEvent nextev;
 
 	while (true) {
 		to_set = check_timeouts(&timeout);

--- a/main.c
+++ b/main.c
@@ -606,9 +606,10 @@ bool process_bindings(const keymap_t *keys, int len, KeySym ksym, int state, int
 		{
 			if (keys[i].cmd.func(keys[i].arg))
 				*dirty = true;
+			return true;
 		}
 	}
-	return 1;
+	return false;
 }
 
 void on_keypress(XKeyEvent *kev)

--- a/main.c
+++ b/main.c
@@ -596,10 +596,11 @@ end:
 	redraw();
 }
 
-bool process_bindings(const keymap_t *keys, int len, KeySym ksym, int state, bool *dirty) {
-	for (int i = 0; i < len; i++) {
-		if (keys[i].ksym_or_button == ksym &&
-			MODMASK(keys[i].mask) == MODMASK(state) &&
+bool process_bindings(const keymap_t *keys, int len, KeySym ksym, int state, int implict_mod, bool *dirty) {
+	int i;
+	for (i = 0; i < len; i++) {
+		if ((keys[i].ksym_or_button == ksym || keys[i].ksym_or_button == 0) &&
+			(keys[i].mask == AnyModifier || MODMASK(keys[i].mask | implict_mod) == MODMASK(state)) &&
 			keys[i].cmd.func &&
 			(keys[i].cmd.mode == MODE_ALL || keys[i].cmd.mode == mode))
 		{
@@ -638,7 +639,7 @@ void on_keypress(XKeyEvent *kev)
 		prefix = prefix * 10 + (int) (key - '0');
 		return;
 	} else {
-		process_bindings(keys, ARRLEN(keys), ksym, kev->state, &dirty);
+		process_bindings(keys, ARRLEN(keys), ksym, kev->state, sh, &dirty);
 	}
 	if (dirty)
 		redraw();
@@ -654,7 +655,7 @@ void on_buttonpress(XButtonEvent *bev)
 	if (mode == MODE_IMAGE) {
 		set_timeout(reset_cursor, TO_CURSOR_HIDE, true);
 		reset_cursor();
-		process_bindings(buttons, ARRLEN(buttons), bev->button, bev->state, &dirty);
+		process_bindings(buttons, ARRLEN(buttons), bev->button, bev->state, 0, &dirty);
 		if (dirty)
 			redraw();
 	} else {

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -175,6 +175,7 @@ typedef struct {
 	KeySym ksym_or_button;
 	cmd_t cmd;
 	arg_t arg;
+	bool* enabled;
 } keymap_t;
 
 typedef keymap_t button_t;
@@ -281,6 +282,8 @@ struct opt {
 };
 
 extern const opt_t *options;
+
+extern bool key_handler_enabled;
 
 void print_usage(void);
 void print_version(void);

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -172,17 +172,12 @@ typedef struct {
 
 typedef struct {
 	unsigned int mask;
-	KeySym ksym;
+	KeySym ksym_or_button;
 	cmd_t cmd;
 	arg_t arg;
 } keymap_t;
 
-typedef struct {
-	unsigned int mask;
-	unsigned int button;
-	cmd_t cmd;
-	arg_t arg;
-} button_t;
+typedef keymap_t button_t;
 
 
 /* image.c */


### PR DESCRIPTION
Think the keyhandler and to a lesser extent prefix code are left overs from sxiv. Not trying to get them removed per-say, but don't want to keep special casing them. Default behavior isn't intended to be broken

This PR has the following benefits

- Allows keys 0-9 to be bound with or without a modifier
- Allows the entire "prefix" notion to be disabled
- Allows for a modifier to be used to disable the keyhandler
- The current XEvent is now public so functions can use that to get the literal key pressed
- Added wildcard modifiers
- Combined the processing on key and button bindings to save code.
- The prefix and keyhandler code are written as normal functions. So any different behavior desired could be achieved by the user in their own config.h. 

The only breaking change is that key/mouse bindings matching will stop at the first match. This isn't an option unlike in #133. All nsxiv should be updated to have the same effect. There are ways to do this without breaking existing feature/bug/side effects, but don't think it is worth as users could achieve the same thing on their own regardless.

I haven't tested this yet, but I think the idea gets across. Relates to what was originally #78 and #131 as on_keypress and on_button_press could be significantly shrunk.