### PR TITLE
mark functions and vars as static

### DIFF
--- a/autoreload_inotify.c
+++ b/autoreload_inotify.c
@@ -24,7 +24,7 @@
 #include <unistd.h>
 #include <sys/inotify.h>
 
-union {
+static union {
 	char d[4096]; /* aligned buffer */
 	struct inotify_event e;
 } buf;

--- a/image.c
+++ b/image.c
@@ -114,7 +114,7 @@ void exif_auto_orientate(const fileinfo_t *file)
 #endif
 
 #if HAVE_LIBGIF
-bool img_load_gif(img_t *img, const fileinfo_t *file)
+static bool img_load_gif(img_t *img, const fileinfo_t *file)
 {
 	GifFileType *gif;
 	GifRowType *rows = NULL;
@@ -295,7 +295,7 @@ bool img_load_gif(img_t *img, const fileinfo_t *file)
 
 
 #if HAVE_LIBWEBP
-bool is_webp(const char *path)
+static bool is_webp(const char *path)
 {
 	/* The size (in bytes) of the largest amount of data required to verify a WebP image. */
 	enum { max = 30 };
@@ -316,7 +316,7 @@ bool is_webp(const char *path)
  * x        NULL  = load the first frame as an Imlib_Image
  * NULL     x     = load all frames into img->multi.
  */
-bool img_load_webp(const fileinfo_t *file, Imlib_Image *fframe, img_t *img)
+static bool img_load_webp(const fileinfo_t *file, Imlib_Image *fframe, img_t *img)
 {
 	FILE *webp_file;
 	WebPData data;
@@ -507,7 +507,7 @@ CLEANUP void img_close(img_t *img, bool decache)
 	}
 }
 
-void img_check_pan(img_t *img, bool moved)
+static void img_check_pan(img_t *img, bool moved)
 {
 	win_t *win;
 	float w, h, ox, oy;
@@ -535,7 +535,7 @@ void img_check_pan(img_t *img, bool moved)
 		img->dirty = true;
 }
 
-bool img_fit(img_t *img)
+static bool img_fit(img_t *img)
 {
 	float z, zw, zh;
 
@@ -723,7 +723,7 @@ bool img_pos(img_t *img, float x, float y)
 	}
 }
 
-bool img_move(img_t *img, float dx, float dy)
+static bool img_move(img_t *img, float dx, float dy)
 {
 	return img_pos(img, img->x + dx, img->y + dy);
 }
@@ -873,7 +873,7 @@ bool img_change_gamma(img_t *img, int d)
 	}
 }
 
-bool img_frame_goto(img_t *img, int n)
+static bool img_frame_goto(img_t *img, int n)
 {
 	if (n < 0 || n >= img->multi.cnt || n == img->multi.sel)
 		return false;

--- a/main.c
+++ b/main.c
@@ -67,7 +67,7 @@ int markidx;
 int prefix;
 bool extprefix;
 
-bool resized = false;
+static bool resized = false;
 
 typedef struct {
 	int err;
@@ -97,7 +97,7 @@ timeout_t timeouts[] = {
 /**************************
   function implementations
  **************************/
-void cleanup(void)
+static void cleanup(void)
 {
 	img_close(&img, false);
 	arl_cleanup(&arl);
@@ -113,7 +113,7 @@ static bool xgetline(char **lineptr, size_t *n)
 	return len > 0;
 }
 
-void check_add_file(char *filename, bool given)
+static void check_add_file(char *filename, bool given)
 {
 	char *path;
 
@@ -203,7 +203,7 @@ void reset_timeout(timeout_f handler)
 	}
 }
 
-bool check_timeouts(struct timeval *t)
+static bool check_timeouts(struct timeval *t)
 {
 	int i = 0, tdiff, tmin = -1;
 	struct timeval now;
@@ -265,7 +265,7 @@ void open_info(void)
 	}
 }
 
-void read_info(void)
+static void read_info(void)
 {
 	ssize_t i, n;
 	char buf[BAR_L_LEN];
@@ -347,7 +347,7 @@ bool mark_image(int n, bool on)
 	return false;
 }
 
-void bar_put(win_bar_t *bar, const char *fmt, ...)
+static void bar_put(win_bar_t *bar, const char *fmt, ...)
 {
 	size_t len = bar->size - (bar->p - bar->buf), n;
 	va_list ap;
@@ -358,7 +358,7 @@ void bar_put(win_bar_t *bar, const char *fmt, ...)
 	va_end(ap);
 }
 
-void update_info(void)
+static void update_info(void)
 {
 	unsigned int i, fn, fw;
 	const char * mark;
@@ -507,7 +507,7 @@ void handle_key_handler(bool init)
 	win_draw(&win);
 }
 
-void run_key_handler(const char *key, unsigned int mask)
+static void run_key_handler(const char *key, unsigned int mask)
 {
 	pid_t pid;
 	FILE *pfs;
@@ -605,8 +605,8 @@ end:
 	redraw();
 }
 
-bool process_bindings(const keymap_t *keys, unsigned int len,
-                      KeySym ksym_or_button, unsigned int state)
+static bool process_bindings(const keymap_t *keys, unsigned int len,
+                             KeySym ksym_or_button, unsigned int state)
 {
 	unsigned int i;
 	bool dirty = false;
@@ -624,7 +624,7 @@ bool process_bindings(const keymap_t *keys, unsigned int len,
 	return dirty;
 }
 
-void on_keypress(XKeyEvent *kev)
+static void on_keypress(XKeyEvent *kev)
 {
 	unsigned int sh = 0;
 	KeySym ksym, shksym;
@@ -659,7 +659,7 @@ void on_keypress(XKeyEvent *kev)
 	prefix = 0;
 }
 
-void on_buttonpress(XButtonEvent *bev)
+static void on_buttonpress(XButtonEvent *bev)
 {
 	int sel;
 	bool dirty = false;
@@ -720,7 +720,7 @@ void on_buttonpress(XButtonEvent *bev)
 	prefix = 0;
 }
 
-void run(void)
+static void run(void)
 {
 	int xfd;
 	fd_set fds;
@@ -837,7 +837,7 @@ void run(void)
 	}
 }
 
-int fncmp(const void *a, const void *b)
+static int fncmp(const void *a, const void *b)
 {
 	return strcoll(((fileinfo_t*) a)->name, ((fileinfo_t*) b)->name);
 }
@@ -847,7 +847,7 @@ void sigchld(int sig)
 	while (waitpid(-1, NULL, WNOHANG) > 0);
 }
 
-void setup_signal(int sig, void (*handler)(int sig))
+static void setup_signal(int sig, void (*handler)(int sig))
 {
 	struct sigaction sa;
 

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -233,7 +233,6 @@ bool img_fit_win(img_t*, scalemode_t);
 bool img_zoom(img_t*, int);
 bool img_zoom_to(img_t*, float);
 bool img_pos(img_t*, float, float);
-bool img_move(img_t*, float, float);
 bool img_pan(img_t*, direction_t, int);
 bool img_pan_edge(img_t*, direction_t);
 void img_rotate(img_t*, degree_t);
@@ -283,7 +282,6 @@ struct opt {
 extern const opt_t *options;
 
 void print_usage(void);
-void print_version(void);
 void parse_options(int, char**);
 
 

--- a/options.c
+++ b/options.c
@@ -26,8 +26,7 @@
 #include <string.h>
 #include <unistd.h>
 
-opt_t _options;
-const opt_t *options = (const opt_t*) &_options;
+const opt_t *options;
 
 void print_usage(void)
 {
@@ -36,7 +35,7 @@ void print_usage(void)
 	       "[-z ZOOM] FILES...\n");
 }
 
-void print_version(void)
+static void print_version(void)
 {
 	puts("nsxiv " VERSION);
 }
@@ -46,6 +45,8 @@ void parse_options(int argc, char **argv)
 	int n, opt;
 	char *end, *s;
 	const char *scalemodes = "dfFwh";
+	static opt_t _options;
+	options = &_options;
 
 	progname = strrchr(argv[0], '/');
 	progname = progname ? progname + 1 : argv[0];

--- a/thumbs.c
+++ b/thumbs.c
@@ -38,7 +38,7 @@ Imlib_Image img_open(const fileinfo_t*);
 static char *cache_dir;
 extern const int fileidx;
 
-char* tns_cache_filepath(const char *filepath)
+static char* tns_cache_filepath(const char *filepath)
 {
 	size_t len;
 	char *cfile = NULL;
@@ -55,7 +55,7 @@ char* tns_cache_filepath(const char *filepath)
 	return cfile;
 }
 
-Imlib_Image tns_cache_load(const char *filepath, bool *outdated)
+static Imlib_Image tns_cache_load(const char *filepath, bool *outdated)
 {
 	char *cfile;
 	struct stat cstats, fstats;
@@ -76,7 +76,7 @@ Imlib_Image tns_cache_load(const char *filepath, bool *outdated)
 	return im;
 }
 
-void tns_cache_write(Imlib_Image im, const char *filepath, bool force)
+static void tns_cache_write(Imlib_Image im, const char *filepath, bool force)
 {
 	char *cfile, *dirend;
 	struct stat cstats, fstats;
@@ -200,7 +200,7 @@ CLEANUP void tns_free(tns_t *tns)
 	cache_dir = NULL;
 }
 
-Imlib_Image tns_scale_down(Imlib_Image im, int dim)
+static Imlib_Image tns_scale_down(Imlib_Image im, int dim)
 {
 	int w, h;
 	float z, zw, zh;
@@ -374,7 +374,7 @@ void tns_unload(tns_t *tns, int n)
 	}
 }
 
-void tns_check_view(tns_t *tns, bool scrolled)
+static void tns_check_view(tns_t *tns, bool scrolled)
 {
 	int r;
 

--- a/window.c
+++ b/window.c
@@ -63,7 +63,7 @@ static int barheight;
 Atom atoms[ATOM_COUNT];
 
 #if HAVE_LIBFONTS
-void win_init_font(const win_env_t *e, const char *fontstr)
+static void win_init_font(const win_env_t *e, const char *fontstr)
 {
 	int fontheight = 0;
 	if ((font = XftFontOpenName(e->dpy, e->scr, fontstr)) == NULL)
@@ -74,21 +74,21 @@ void win_init_font(const win_env_t *e, const char *fontstr)
 	XftFontClose(e->dpy, font);
 }
 
-void xft_alloc_color(const win_env_t *e, const char *name, XftColor *col)
+static void xft_alloc_color(const win_env_t *e, const char *name, XftColor *col)
 {
 	if (!XftColorAllocName(e->dpy, e->vis, e->cmap, name, col))
 		error(EXIT_FAILURE, 0, "Error allocating color '%s'", name);
 }
 #endif /* HAVE_LIBFONTS */
 
-void win_alloc_color(const win_env_t *e, const char *name, XColor *col)
+static void win_alloc_color(const win_env_t *e, const char *name, XColor *col)
 {
 	XColor screen;
 	if (!XAllocNamedColor(e->dpy, e->cmap, name, &screen, col))
 		error(EXIT_FAILURE, 0, "Error allocating color '%s'", name);
 }
 
-const char* win_res(XrmDatabase db, const char *name, const char *def)
+static const char* win_res(XrmDatabase db, const char *name, const char *def)
 {
 	char *type;
 	XrmValue ret;
@@ -396,8 +396,8 @@ void win_clear(win_t *win)
 }
 
 #if HAVE_LIBFONTS
-int win_draw_text(win_t *win, XftDraw *d, const XftColor *color, int x, int y,
-                  char *text, int len, int w)
+static int win_draw_text(win_t *win, XftDraw *d, const XftColor *color,
+                         int x, int y, char *text, int len, int w)
 {
 	int err, tw = 0;
 	char *t, *next;
@@ -430,7 +430,7 @@ int win_draw_text(win_t *win, XftDraw *d, const XftColor *color, int x, int y,
 	return tw;
 }
 
-void win_draw_bar(win_t *win)
+static void win_draw_bar(win_t *win)
 {
 	int len, x, y, w, tw;
 	win_env_t *e;
@@ -466,7 +466,7 @@ void win_draw_bar(win_t *win)
 	XftDrawDestroy(d);
 }
 #else
-void win_draw_bar(win_t *win){}
+static void win_draw_bar(win_t *win){}
 #endif /* HAVE_LIBFONTS */
 
 void win_draw(win_t *win)


### PR DESCRIPTION
the goal here to mark functions and variables not used outside the
translation unit as static. main reason for this is cleanliness. however
as a side-effect this can help compilers optimize better as it now has
guarantee that a certain function won't be called outside of that
translation unit.