### PR TITLE
make width of navigation area configurable

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -29,7 +29,7 @@ void load_image(int);
 bool mark_image(int, bool);
 void close_info(void);
 void open_info(void);
-int ptr_third_x(void);
+int nav_button(void);
 void redraw(void);
 void reset_cursor(void);
 void animate(void);
@@ -286,7 +286,7 @@ bool ci_navigate(arg_t n)
 
 bool ci_cursor_navigate(arg_t _)
 {
-	return ci_navigate(ptr_third_x() - 1);
+	return ci_navigate(nav_button() - 1);
 }
 
 bool ci_alternate(arg_t _)

--- a/config.def.h
+++ b/config.def.h
@@ -60,12 +60,12 @@ static const bool ANTI_ALIAS = true;
 static const bool ALPHA_LAYER = false;
 
 /* width of navigation area on left and right side of the window:
- * value >= 1 defines the width as number of pixels (convert to integer),
- * 0 < value < 1 defines the width as the fraction of the window width,
- * value <= 0 is meaningless, will use the default value 0.33,
- * the area width will be kept under half the window width in any case.
+ * a negative value defines the width as number of pixels (without the negative sign),
+ * a positive value defines the width as percentage of the window width,
+ * 0 disables cursor navigation,
+ * the area width will be kept under half of the window width in any case.
  */
-static const float NAV_WIDTH = 0.33;
+static const int NAV_WIDTH = 33;
 
 #endif
 #ifdef _THUMBS_CONFIG

--- a/config.def.h
+++ b/config.def.h
@@ -173,15 +173,14 @@ static const button_t buttons[] = {
 	{ 0,            5,                g_zoom,               -1 },
 };
 
+/* true means NAV_WIDTH is relative (33%), false means absolute (33 pixels) */
+static const bool NAV_IS_REL = true;
+/* width of navigation area, 0 disables cursor navigation, */
+static const unsigned int NAV_WIDTH = 33;
+
 /* mouse cursor on left, middle and right part of the window */
 static const cursor_t imgcursor[3] = {
 	CURSOR_LEFT, CURSOR_ARROW, CURSOR_RIGHT
 };
-
-/* true means NAV_WIDTH is relative (33%), false means absolute (33 pixels) */
-static const bool NAV_IS_REL = true;
-
-/* width of navigation area, 0 disables cursor navigation, */
-static const int NAV_WIDTH = 33;
 
 #endif

--- a/config.def.h
+++ b/config.def.h
@@ -178,12 +178,10 @@ static const cursor_t imgcursor[3] = {
 	CURSOR_LEFT, CURSOR_ARROW, CURSOR_RIGHT
 };
 
-/* width of navigation area on left and right side of the window:
- * a positive value defines the width as percentage of the window width,
- * a negative value defines the width in pixels (without the negative sign),
- * 0 disables cursor navigation,
- * the area width will be kept under half of the window width in any case.
- */
+/* width of navigation area, 0 disables cursor navigation, */
 static const int NAV_WIDTH = 33;
+
+/* true means NAV_WIDTH is relative (33%), false means absolute (33 pixels) */
+static const bool NAV_IS_REL = true;
 
 #endif

--- a/config.def.h
+++ b/config.def.h
@@ -178,10 +178,10 @@ static const cursor_t imgcursor[3] = {
 	CURSOR_LEFT, CURSOR_ARROW, CURSOR_RIGHT
 };
 
-/* width of navigation area, 0 disables cursor navigation, */
-static const int NAV_WIDTH = 33;
-
 /* true means NAV_WIDTH is relative (33%), false means absolute (33 pixels) */
 static const bool NAV_IS_REL = true;
+
+/* width of navigation area, 0 disables cursor navigation, */
+static const int NAV_WIDTH = 33;
 
 #endif

--- a/config.def.h
+++ b/config.def.h
@@ -59,6 +59,14 @@ static const bool ANTI_ALIAS = true;
  */
 static const bool ALPHA_LAYER = false;
 
+/* width of navigation area on left and right side of the window:
+ * value >= 1 defines the width as number of pixels (convert to integer),
+ * 0 < value < 1 defines the width as the fraction of the window width,
+ * value <= 0 is meaningless, will use the default value 0.33,
+ * the area width will be kept under half the window width in any case.
+ */
+static const float NAV_WIDTH = 0.33;
+
 #endif
 #ifdef _THUMBS_CONFIG
 

--- a/config.def.h
+++ b/config.def.h
@@ -59,14 +59,6 @@ static const bool ANTI_ALIAS = true;
  */
 static const bool ALPHA_LAYER = false;
 
-/* width of navigation area on left and right side of the window:
- * a negative value defines the width as number of pixels (without the negative sign),
- * a positive value defines the width as percentage of the window width,
- * 0 disables cursor navigation,
- * the area width will be kept under half of the window width in any case.
- */
-static const int NAV_WIDTH = 33;
-
 #endif
 #ifdef _THUMBS_CONFIG
 
@@ -185,5 +177,13 @@ static const button_t buttons[] = {
 static const cursor_t imgcursor[3] = {
 	CURSOR_LEFT, CURSOR_ARROW, CURSOR_RIGHT
 };
+
+/* width of navigation area on left and right side of the window:
+ * a negative value defines the width as number of pixels (without the negative sign),
+ * a positive value defines the width as percentage of the window width,
+ * 0 disables cursor navigation,
+ * the area width will be kept under half of the window width in any case.
+ */
+static const int NAV_WIDTH = 33;
 
 #endif

--- a/config.def.h
+++ b/config.def.h
@@ -179,8 +179,8 @@ static const cursor_t imgcursor[3] = {
 };
 
 /* width of navigation area on left and right side of the window:
- * a negative value defines the width as number of pixels (without the negative sign),
  * a positive value defines the width as percentage of the window width,
+ * a negative value defines the width in pixels (without the negative sign),
  * 0 disables cursor navigation,
  * the area width will be kept under half of the window width in any case.
  */

--- a/main.c
+++ b/main.c
@@ -401,9 +401,9 @@ int nav_button(void)
 
 	win_cursor_pos(&win, &x, &y);
 	nav_width = NAV_WIDTH > 0 ? win.w * NAV_WIDTH / 100 : -NAV_WIDTH;
-	nav_width = MIN(nav_width, win.w / 2);
+	nav_width = MIN(nav_width, (win.w + 1) / 2);
 
-	return x <= nav_width ? 0 : x < win.w - nav_width ? 1 : 2;
+	return x < nav_width ? 0 : x < win.w - nav_width ? 1 : 2;
 }
 
 void redraw(void)

--- a/main.c
+++ b/main.c
@@ -20,6 +20,7 @@
 #include "nsxiv.h"
 #include "commands.h"
 #define _MAPPINGS_CONFIG
+#define _IMAGE_CONFIG
 #include "config.h"
 
 #include <stdlib.h>
@@ -392,12 +393,15 @@ void update_info(void)
 	}
 }
 
-int ptr_third_x(void)
+int nav_button(void)
 {
-	int x, y;
+	int x, y, nw;
 
 	win_cursor_pos(&win, &x, &y);
-	return MAX(0, MIN(2, (x / (win.w * 0.33))));
+	nw = (NAV_WIDTH <= 0 ? 0.33 : NAV_WIDTH) * (NAV_WIDTH >= 1 ? 1 : win.w);
+	nw = MIN(nw, win.w / 2);
+
+	return x <= nw ? 0 : x < win.w - nw ? 1 : 2;
 }
 
 void redraw(void)
@@ -431,7 +435,7 @@ void reset_cursor(void)
 		for (i = 0; i < ARRLEN(timeouts); i++) {
 			if (timeouts[i].handler == reset_cursor) {
 				if (timeouts[i].active) {
-					c = ptr_third_x();
+					c = nav_button();
 					c = MAX(fileidx > 0 ? 0 : 1, c);
 					c = MIN(fileidx + 1 < filecnt ? 2 : 1, c);
 					cursor = imgcursor[c];

--- a/main.c
+++ b/main.c
@@ -395,13 +395,13 @@ void update_info(void)
 
 int nav_button(void)
 {
-	int x, y, nw;
+	int x, y, nav_width;
 
 	win_cursor_pos(&win, &x, &y);
-	nw = (NAV_WIDTH <= 0 ? 0.33 : NAV_WIDTH) * (NAV_WIDTH >= 1 ? 1 : win.w);
-	nw = MIN(nw, win.w / 2);
+	nav_width = (nav_width <= 0 ? 0.33 : nav_width) * (nav_width >= 1 ? 1 : win.w);
+	nav_width = MIN(nav_width, win.w / 2);
 
-	return x <= nw ? 0 : x < win.w - nw ? 1 : 2;
+	return x <= nav_width ? 0 : x < win.w - nav_width ? 1 : 2;
 }
 
 void redraw(void)

--- a/main.c
+++ b/main.c
@@ -394,16 +394,16 @@ void update_info(void)
 
 int nav_button(void)
 {
-	int x, y, nav_width;
+	int x, y, nw;
 
 	if (NAV_WIDTH == 0)
 		return 1;
 
 	win_cursor_pos(&win, &x, &y);
-	nav_width = NAV_IS_REL ? win.w * NAV_WIDTH / 100 : NAV_WIDTH;
-	nav_width = MIN(nav_width, (win.w + 1) / 2);
+	nw = NAV_IS_REL ? win.w * NAV_WIDTH / 100 : NAV_WIDTH;
+	nw = MIN(nw, (win.w + 1) / 2);
 
-	return x < nav_width ? 0 : x < win.w - nav_width ? 1 : 2;
+	return x < nw ? 0 : x < win.w - nw ? 1 : 2;
 }
 
 void redraw(void)

--- a/main.c
+++ b/main.c
@@ -400,7 +400,7 @@ int nav_button(void)
 		return 1;
 
 	win_cursor_pos(&win, &x, &y);
-	nav_width = NAV_WIDTH > 0 ? win.w * NAV_WIDTH / 100 : -NAV_WIDTH;
+	nav_width = NAV_IS_REL ? win.w * NAV_WIDTH / 100 : NAV_WIDTH;
 	nav_width = MIN(nav_width, (win.w + 1) / 2);
 
 	return x < nav_width ? 0 : x < win.w - nav_width ? 1 : 2;

--- a/main.c
+++ b/main.c
@@ -397,8 +397,11 @@ int nav_button(void)
 {
 	int x, y, nav_width;
 
+	if (NAV_WIDTH == 0)
+		return 1;
+
 	win_cursor_pos(&win, &x, &y);
-	nav_width = (nav_width <= 0 ? 0.33 : nav_width) * (nav_width >= 1 ? 1 : win.w);
+	nav_width = NAV_WIDTH > 0 ? win.w * NAV_WIDTH / 100 : -NAV_WIDTH;
 	nav_width = MIN(nav_width, win.w / 2);
 
 	return x <= nav_width ? 0 : x < win.w - nav_width ? 1 : 2;

--- a/main.c
+++ b/main.c
@@ -20,7 +20,6 @@
 #include "nsxiv.h"
 #include "commands.h"
 #define _MAPPINGS_CONFIG
-#define _IMAGE_CONFIG
 #include "config.h"
 
 #include <stdlib.h>

--- a/main.c
+++ b/main.c
@@ -403,7 +403,12 @@ int nav_button(void)
 	nw = NAV_IS_REL ? win.w * NAV_WIDTH / 100 : NAV_WIDTH;
 	nw = MIN(nw, (win.w + 1) / 2);
 
-	return x < nw ? 0 : x < win.w - nw ? 1 : 2;
+	if (x < nw)
+		return 0;
+	else if (x < win.w-nw)
+		return 1;
+	else
+		return 2;
 }
 
 void redraw(void)


### PR DESCRIPTION
Now the navigation area can be any number of pixels wide, or any fraction of the window width. Default is still to be a third of the window width.

(I used many `?:` operators, if that compromises the readability, I can expand them with if-else)

---

One special use case is, if the user want the navigating and dragging behavior similar to some main-stream image viewers, he can change the navigation area smaller, and make the relative drag bind to button1. Then he will have most of the window area for dragging and two small areas for navigation, all with the left mouse button. (slightly related to #117)

Or one can make left and right half of the window for navigation, using up all the window area :)