### PR TITLE
bring back zoom_levels

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -32,10 +32,13 @@ static const suffixmode_t TITLE_SUFFIXMODE = SUFFIX_BASENAME;
 #endif
 #ifdef _IMAGE_CONFIG
 
-/* zoom level of 1.0 means 100% */
-static const float ZOOM_MIN  = 0.01;
-static const float ZOOM_MAX  = 20.0;
-static const float ZOOM_STEP = 1.2599210498948732; /* 2^(1/3) */
+/* levels (in percent) to use when zooming via '-' and '+':
+ * (first/last value is used as min/max zoom level)
+ */
+static const float zoom_levels[] = {
+	 12.5,  25.0,  50.0,  75.0,
+	100.0, 150.0, 200.0, 400.0, 800.0
+};
 
 /* default slideshow delay (in sec, overwritten via -S option): */
 static const int SLIDESHOW_DELAY = 5;

--- a/image.c
+++ b/image.c
@@ -43,6 +43,9 @@ enum { DEF_GIF_DELAY = 75 };
 enum { DEF_WEBP_DELAY = 75 };
 #endif
 
+static const float ZOOM_MIN = zoom_levels[0] / 100;
+static const float ZOOM_MAX = zoom_levels[ARRLEN(zoom_levels)-1] / 100;
+
 void img_init(img_t *img, win_t *win)
 {
 	imlib_context_set_display(win->env.dpy);
@@ -699,8 +702,16 @@ bool img_zoom_to(img_t *img, float z)
 
 bool img_zoom(img_t *img, int d)
 {
-	const float z = img->zoom * (d > 0 ? ZOOM_STEP : 1/ZOOM_STEP);
-	return img_zoom_to(img, z);
+	int i = d > 0 ? 0 : ARRLEN(zoom_levels)-1;
+	if (d > 0) {
+		while (i < ARRLEN(zoom_levels) && zoom_levels[i]/100 <= img->zoom)
+			++i;
+	} else {
+		while (i >= 0 && zoom_levels[i]/100 >= img->zoom)
+			--i;
+	}
+	i = MIN(MAX(i, 0), ARRLEN(zoom_levels)-1);
+	return img_zoom_to(img, zoom_levels[i]/100);
 }
 
 bool img_pos(img_t *img, float x, float y)


### PR DESCRIPTION
this still keeps the shorter zoom logic, but adds back the zoom_levels
array so that stay close to sxiv.

- - -

Seemed like an easy enough change so didn't feel like waiting for the resolution of #148. For now keeping it "draft" though. Also note, I haven't tested this extensively. But it seems to work from some basic quick test.