### PR TITLE
Fully customizable window title

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -16,18 +16,14 @@ static const char *DEFAULT_BAR_FG     = NULL;  /* NULL means it will default to 
 static const char *DEFAULT_FONT       = "monospace-8";
 #endif
 
+
+static const char* (*get_window_title)(const char*) = default_window_title;
+
 #endif
 #ifdef _TITLE_CONFIG
 
 /* default title prefix */
 static const char *TITLE_PREFIX = "nsxiv - ";
-
-/* default title suffixmode, available options are:
- * SUFFIX_EMPTY
- * SUFFIX_BASENAME
- * SUFFIX_FULLPATH
- */
-static const suffixmode_t TITLE_SUFFIXMODE = SUFFIX_BASENAME;
 
 #endif
 #ifdef _IMAGE_CONFIG

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -116,12 +116,6 @@ typedef enum {
 	FF_TN_INIT = 4
 } fileflags_t;
 
-typedef enum {
-	SUFFIX_EMPTY,
-	SUFFIX_BASENAME,
-	SUFFIX_FULLPATH
-} suffixmode_t;
-
 typedef struct {
 	const char *name; /* as given by user */
 	const char *path; /* always absolute */
@@ -276,7 +270,6 @@ struct opt {
 	char *geometry;
 	char *res_name;
 	const char *title_prefix;
-	suffixmode_t title_suffixmode;
 
 	/* misc flags: */
 	bool quiet;
@@ -449,5 +442,7 @@ void win_draw_rect(win_t*, int, int, int, int, bool, int, unsigned long);
 void win_set_title(win_t*, const char*);
 void win_set_cursor(win_t*, cursor_t);
 void win_cursor_pos(win_t*, int*, int*);
+
+const char* default_window_title(const char* path);
 
 #endif /* NSXIV_H */

--- a/options.c
+++ b/options.c
@@ -69,7 +69,6 @@ void parse_options(int argc, char **argv)
 	_options.geometry = NULL;
 	_options.res_name = NULL;
 	_options.title_prefix = TITLE_PREFIX;
-	_options.title_suffixmode = TITLE_SUFFIXMODE;
 
 	_options.quiet = false;
 	_options.thumb_mode = false;
@@ -154,13 +153,6 @@ void parse_options(int argc, char **argv)
 				_options.scalemode = s - scalemodes;
 				break;
 			case 'T':
-				if ((s = strrchr(optarg, ':')) != NULL) {
-					*s = '\0';
-					n = strtol(++s, &end, 0);
-					if (*end != '\0' || n < SUFFIX_EMPTY || n > SUFFIX_FULLPATH)
-						error(EXIT_FAILURE, 0, "Invalid argument for option -T suffixmode: %s", s);
-					_options.title_suffixmode = n;
-				}
 				_options.title_prefix = optarg;
 				break;
 			case 't':

--- a/window.c
+++ b/window.c
@@ -494,20 +494,21 @@ void win_draw_rect(win_t *win, int x, int y, int w, int h, bool fill, int lw,
 		XDrawRectangle(win->env.dpy, win->buf.pm, gc, x, y, w, h);
 }
 
+const char* default_window_title(const char* path) {
+	static char title[512];
+
+	const char *basename = strrchr(path, '/') + 1;
+	snprintf(title, sizeof(title) - 1, "%s%s", options->title_prefix, basename);
+	return title;
+}
+
 void win_set_title(win_t *win, const char *path)
 {
-	enum { title_max = 512 };
-	char title[title_max];
-	const char *basename = strrchr(path, '/') + 1;
 
 	/* Return if window is not ready yet */
 	if (win->xwin == None)
 		return;
-
-	snprintf(title, title_max, "%s%s", options->title_prefix,
-	         options->title_suffixmode == SUFFIX_BASENAME ? basename : path);
-	if (options->title_suffixmode == SUFFIX_EMPTY)
-		*(title+strlen(options->title_prefix)) = '\0';
+	const char* title = get_window_title(path);
 
 	XChangeProperty(win->env.dpy, win->xwin, atoms[ATOM__NET_WM_NAME],
 	                XInternAtom(win->env.dpy, "UTF8_STRING", False), 8,


### PR DESCRIPTION
This partially undoes the change introduces in #23 as TITLE_SUFFIX has
been removed. In its place is a function pointer that accepts the
current file path and returns the title. With this the user could
customize the title however they wanted including passing the result to
a shell program or parsing printf like flags.

The '-T' option has been kept so the user can still influence the title
from the cli and the default title hasn't changed.

Closes #97