### PR TITLE
webp: remove unneeded hack and minor cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The following dependencies are optional.
   * libexif : Used for auto-orientation and exif thumbnails.
     Disable via `HAVE_LIBEXIF=0`
   * libwebp : Used for animated webp playback.
+    (NOTE: animated webp also requires Imlib2 v1.7.5 or above)
     Disabled via `HAVE_LIBWEBP=0`.
 
 Please make sure to install the corresponding development packages in case that

--- a/image.c
+++ b/image.c
@@ -302,20 +302,17 @@ static bool img_load_webp(img_t *img, const fileinfo_t *file)
 {
 	FILE *webp_file;
 	WebPData data;
-
 	Imlib_Image im = NULL;
 	struct WebPAnimDecoderOptions opts;
 	WebPAnimDecoder *dec = NULL;
 	struct WebPAnimInfo info;
-	unsigned char *buf = NULL;
+	unsigned char *buf = NULL, *bytes = NULL;
 	int ts;
 	const WebPDemuxer *demux;
 	WebPIterator iter;
 	unsigned long flags;
 	unsigned int delay;
 	bool err = false;
-
-	data.bytes = NULL;
 
 	if ((err = (webp_file = fopen(file->path, "rb")) == NULL)) {
 		error(0, 0, "%s: Error opening webp image", file->name);
@@ -324,11 +321,12 @@ static bool img_load_webp(img_t *img, const fileinfo_t *file)
 	fseek(webp_file, 0L, SEEK_END);
 	data.size = ftell(webp_file);
 	rewind(webp_file);
-	data.bytes = emalloc(data.size);
-	if ((err = fread((unsigned char *)data.bytes, 1, data.size, webp_file) != data.size)) {
+	bytes = emalloc(data.size);
+	if ((err = fread(bytes, 1, data.size, webp_file) != data.size)) {
 		error(0, 0, "%s: Error reading webp image", file->name);
 		goto fail;
 	}
+	data.bytes = bytes;
 
 	/* Setup the WebP Animation Decoder */
 	if ((err = !WebPAnimDecoderOptionsInit(&opts))) {
@@ -391,7 +389,7 @@ static bool img_load_webp(img_t *img, const fileinfo_t *file)
 fail:
 	if (dec != NULL)
 		WebPAnimDecoderDelete(dec);
-	free((unsigned char *)data.bytes);
+	free(bytes);
 	return !err;
 }
 #endif /* HAVE_LIBWEBP */

--- a/image.c
+++ b/image.c
@@ -348,10 +348,7 @@ static bool img_load_webp(img_t *img, const fileinfo_t *file)
 	img->w = WebPDemuxGetI(demux, WEBP_FF_CANVAS_WIDTH);
 	img->h = WebPDemuxGetI(demux, WEBP_FF_CANVAS_HEIGHT);
 
-	if (img->multi.cap == 0) {
-		img->multi.cap = info.frame_count;
-		img->multi.frames = emalloc(img->multi.cap * sizeof(img_frame_t));
-	} else if (info.frame_count > img->multi.cap) {
+	if (info.frame_count > img->multi.cap) {
 		img->multi.cap = info.frame_count;
 		img->multi.frames = erealloc(img->multi.frames,
 		                             img->multi.cap * sizeof(img_frame_t));

--- a/image.c
+++ b/image.c
@@ -314,9 +314,9 @@ static bool img_load_webp(img_t *img, const fileinfo_t *file)
 	unsigned int delay;
 	bool err = false;
 
-	if ((err = (webp_file = fopen(file->path, "rb")) == NULL)) {
-		error(0, 0, "%s: Error opening webp image", file->name);
-		goto fail;
+	if ((webp_file = fopen(file->path, "rb")) == NULL) {
+		error(0, errno, "%s: Error opening webp image", file->name);
+		return false;
 	}
 	fseek(webp_file, 0L, SEEK_END);
 	data.size = ftell(webp_file);
@@ -387,6 +387,7 @@ fail:
 	if (dec != NULL)
 		WebPAnimDecoderDelete(dec);
 	free(bytes);
+	fclose(webp_file);
 	return !err;
 }
 #endif /* HAVE_LIBWEBP */


### PR DESCRIPTION
now that imlib2 is able to load the first frame of an animated-webp
file, we no longer need the `is_webp` check and bypass imlib2 when
loading webp.
    
ref: https://phab.enlightenment.org/T8964