### PR TITLE
Apply -0 to stdin and update key-handler doc

### DIFF
--- a/examples/key-handler
+++ b/examples/key-handler
@@ -3,10 +3,14 @@
 # Example for $XDG_CONFIG_HOME/nsxiv/exec/key-handler
 # Called by nsxiv(1) after the external prefix key (C-x by default) is pressed.
 # The next key combo is passed as its first argument. Passed via stdin are the
-# images to act upon, one path per line: all marked images, if in thumbnail
-# mode and at least one image has been marked, otherwise the current image.
-# nsxiv(1) blocks until this script terminates. It then checks which images
-# have been modified and reloads them.
+# images to act upon: all marked images, if in thumbnail mode and at least one
+# image has been marked, otherwise the current image. nsxiv(1) will block until
+# the handler terminates. It then checks which images have been modified and
+# reloads them.
+
+# By default nsxiv(1) will send one image per-line to stdin, however when using
+# -0 the image list will be NULL separated and the enviornment variable
+# "$NSXIV_USING_NULL" will be set to 1.
 
 # The key combo argument has the following form: "[C-][M-][S-]KEY",
 # where C/M/S indicate Ctrl/Meta(Alt)/Shift modifier states and KEY is the X

--- a/main.c
+++ b/main.c
@@ -549,6 +549,7 @@ void run_key_handler(const char *key, unsigned int mask)
 	         mask & ControlMask ? "C-" : "",
 	         mask & Mod1Mask    ? "M-" : "",
 	         mask & ShiftMask   ? "S-" : "", key);
+	setenv("NSXIV_USING_NULL", options->using_null ? "1" : "0", 1);
 
 	if ((pid = fork()) == 0) {
 		close(pfd[1]);

--- a/main.c
+++ b/main.c
@@ -105,6 +105,14 @@ void cleanup(void)
 	win_close(&win);
 }
 
+static bool xgetline(char **lineptr, size_t *n)
+{
+	ssize_t len = getdelim(lineptr, n, options->using_null ? '\0' : '\n', stdin);
+	if (!options->using_null && len > 0 && (*lineptr)[len-1] == '\n')
+		(*lineptr)[len-1] = '\0';
+	return len > 0;
+}
+
 void check_add_file(char *filename, bool given)
 {
 	char *path;
@@ -853,7 +861,6 @@ int main(int argc, char *argv[])
 {
 	int i, start;
 	size_t n;
-	ssize_t len;
 	char *filename;
 	const char *homedir, *dsuffix = "";
 	struct stat fstats;
@@ -889,11 +896,8 @@ int main(int argc, char *argv[])
 	if (options->from_stdin) {
 		n = 0;
 		filename = NULL;
-		while ((len = getline(&filename, &n, stdin)) > 0) {
-			if (filename[len-1] == '\n')
-				filename[len-1] = '\0';
+		while (xgetline(&filename, &n))
 			check_add_file(filename, true);
-		}
 		free(filename);
 	}
 

--- a/nsxiv.1
+++ b/nsxiv.1
@@ -128,7 +128,7 @@ Set zoom level to ZOOM percent.
 .TP
 .B \-0
 Use NULL-separator. With this option output of \-o and file-list sent to the
-key-handler will be seperated by a NULL character.
+key-handler and the input of \-i will be seperated by a NULL character.
 .SH KEYBOARD COMMANDS
 .SS General
 The following keyboard commands are available in both image and thumbnail mode:

--- a/nsxiv.1
+++ b/nsxiv.1
@@ -439,14 +439,20 @@ located in
 The handler is invoked by pressing
 .BR Ctrl-x .
 The next key combo is passed as its first argument. Passed via stdin are the
-images to act upon, one path per line: all marked images, if in thumbnail mode
-and at least one image has been marked, otherwise the current image.
-nsxiv(1) will block until the handler terminates. It then checks which images
-have been modified and reloads them.
+images to act upon: all marked images, if in thumbnail mode and at least one
+image has been marked, otherwise the current image. nsxiv(1) will block until
+the handler terminates. It then checks which images have been modified and
+reloads them.
+
+By default nsxiv(1) will send one image per-line to stdin, however when using
+\-0 the image list will be NULL separated and the enviornment variable
+"$NSXIV_USING_NULL" will be set to 1.
 
 The key combo argument has the following form: "[C-][M-][S-]KEY",
 where C/M/S indicate Ctrl/Meta(Alt)/Shift modifier states and KEY is the X
 keysym as listed in /usr/include/X11/keysymdef.h without the "XK_" prefix.
+If KEY has an uppercase equivalent, S-KEY is resolved into it. For instance,
+K replaces S-k and Scedilla replaces S-scedilla, but S-Delete is sent as-is.
 
 There is also an example script installed together with nsxiv as
 .IR EGPREFIX/key-handler .


### PR DESCRIPTION
### apply -0 to stdin/-i as well

while i was initially against this since it can be done via `xargs -0`.
the problem with this approach is that there's a limit to how many args
a command can recieve, leading to [problem like this] when opening
large (1k~) amount of images.

there's no limit on how big stdin can be, so being able to read a
null-separated list from stdin doesn't have this problem.

[problem like this]: https://github.com/ranger/ranger/pull/2307#issuecomment-818683515

---

### use arguments for -0

this allows users to fine-tune which aspects they want to be
null-separated. for example one might want `-i` and `-o` to be
null-separated but not keyhandler.
