### PR TITLE
Revert "fix: out-of-bounds access when bg not in color map"

### DIFF
--- a/image.c
+++ b/image.c
@@ -202,10 +202,6 @@ bool img_load_gif(img_t *img, const fileinfo_t *file)
 
 			ptr = data = emalloc(sw * sh * sizeof(DATA32));
 			cmap = gif->Image.ColorMap ? gif->Image.ColorMap : gif->SColorMap;
-			if (bg >= cmap->ColorCount) {
-				err = true;
-				break;
-			}
 			r = cmap->Colors[bg].Red;
 			g = cmap->Colors[bg].Green;
 			b = cmap->Colors[bg].Blue;

--- a/image.c
+++ b/image.c
@@ -202,10 +202,13 @@ bool img_load_gif(img_t *img, const fileinfo_t *file)
 
 			ptr = data = emalloc(sw * sh * sizeof(DATA32));
 			cmap = gif->Image.ColorMap ? gif->Image.ColorMap : gif->SColorMap;
-			r = cmap->Colors[bg].Red;
-			g = cmap->Colors[bg].Green;
-			b = cmap->Colors[bg].Blue;
-			bgpixel = 0x00ffffff & (r << 16 | g << 8 | b);
+			/* if bg > cmap->ColorCount, it is transparent black already */
+			if (cmap && bg >= 0 && bg < cmap->ColorCount) {
+				r = cmap->Colors[bg].Red;
+				g = cmap->Colors[bg].Green;
+				b = cmap->Colors[bg].Blue;
+				bgpixel = 0x00ffffff & (r << 16 | g << 8 | b);
+			}
 
 			for (i = 0; i < sh; i++) {
 				for (j = 0; j < sw; j++) {


### PR DESCRIPTION
with this patch certain gif images will fail to play. one other problem
here is that it suddenly breaks the loop without free-ing data and rows,
leading to a memory leak.

regardless, this needs to be investigated further.

here's an example image where this happens:
https://i.postimg.cc/SQf1TJJg/awoo-study.gif

This reverts commit cca7834e6718c6ff64da42ed5e9770880a3e8ff6.