### PR TITLE
use a dedicated function for processing key/button bindings

### DIFF
--- a/nsxiv.h
+++ b/nsxiv.h
@@ -172,17 +172,12 @@ typedef struct {
 
 typedef struct {
 	unsigned int mask;
-	KeySym ksym;
+	KeySym ksym_or_button;
 	cmd_t cmd;
 	arg_t arg;
 } keymap_t;
 
-typedef struct {
-	unsigned int mask;
-	unsigned int button;
-	cmd_t cmd;
-	arg_t arg;
-} button_t;
+typedef keymap_t button_t;
 
 
 /* image.c */


### PR DESCRIPTION
Note: this PR differs from the previous https://github.com/nsxiv/nsxiv/pull/157 in that it clears `sh` from `state` instead of passing it as a separate argument to `process_bindings`. Unless there's some edge case I'm failing to think of, it should work fine without needing to explicitly send `sh` as an argument.