### PR TITLE
allow configuring imlib2's cache size

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -60,7 +60,7 @@ static const bool ANTI_ALIAS = true;
 static const bool ALPHA_LAYER = false;
 
 /* cache size for imlib2, in bytes */
-static const int CACHE_SIZE = 4 * 1024 * 1024; /* 4Mb */
+static const int CACHE_SIZE = 4 * 1024 * 1024; /* 4MiB */
 
 #endif
 #ifdef _THUMBS_CONFIG

--- a/config.def.h
+++ b/config.def.h
@@ -59,6 +59,9 @@ static const bool ANTI_ALIAS = true;
  */
 static const bool ALPHA_LAYER = false;
 
+/* cache size for imlib2, in bytes */
+static const int CACHE_SIZE = 4 * 1024 * 1024; /* 4Mb */
+
 #endif
 #ifdef _THUMBS_CONFIG
 

--- a/config.def.h
+++ b/config.def.h
@@ -59,7 +59,10 @@ static const bool ANTI_ALIAS = true;
  */
 static const bool ALPHA_LAYER = false;
 
-/* cache size for imlib2, in bytes */
+/* cache size for imlib2, in bytes. For backwards compatibility reasons, the
+ * size is kept at 4MiB. For most users, it is advised to pick a value above
+ * 128MiB for better image (re)loading performance.
+ */
 static const int CACHE_SIZE = 4 * 1024 * 1024; /* 4MiB */
 
 #endif

--- a/image.c
+++ b/image.c
@@ -48,6 +48,7 @@ void img_init(img_t *img, win_t *win)
 	imlib_context_set_display(win->env.dpy);
 	imlib_context_set_visual(win->env.vis);
 	imlib_context_set_colormap(win->env.cmap);
+	imlib_set_cache_size(CACHE_SIZE);
 
 	img->im = NULL;
 	img->win = win;


### PR DESCRIPTION
by default imlib2 uses a 4mb cache, which is quite small. this allows
users who have more memory to spare to set a bigger cache size and avoid
reloading an already viewed image if it fits into the cache.