### PR TITLE
rename: keyhandler_abort -> KEYHANDLER_ABORT

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -75,7 +75,7 @@ static const int THUMB_SIZE = 3;
 static const int ignore_mask = Mod2Mask | LockMask;
 
 /* abort the keyhandler */
-static const KeySym keyhandler_abort = XK_Escape;
+static const KeySym KEYHANDLER_ABORT = XK_Escape;
 
 /* keyboard mappings for image and thumbnail mode: */
 static const keymap_t keys[] = {

--- a/main.c
+++ b/main.c
@@ -499,7 +499,7 @@ void handle_key_handler(bool init)
 	if (init) {
 		close_info();
 		snprintf(win.bar.l.buf, win.bar.l.size, "Getting key handler input "
-		         "(%s to abort)...", XKeysymToString(keyhandler_abort));
+		         "(%s to abort)...", XKeysymToString(KEYHANDLER_ABORT));
 	} else { /* abort */
 		open_info();
 		update_info();
@@ -642,7 +642,7 @@ static void on_keypress(XKeyEvent *kev)
 	}
 	if (IsModifierKey(ksym))
 		return;
-	if (extprefix && ksym == keyhandler_abort && MODMASK(kev->state) == 0) {
+	if (extprefix && ksym == KEYHANDLER_ABORT && MODMASK(kev->state) == 0) {
 		handle_key_handler(false);
 	} else if (extprefix) {
 		run_key_handler(XKeysymToString(ksym), kev->state & ~sh);


### PR DESCRIPTION
with the exception of arrays, all other var names in config.h are in ALL
CAPS. since keyhandler_abort is an unreleased feature, it should be okay
to rename it for consistency.

though.. in the future we should be more careful about naming when
adding new vars to config.h (or the codebase in general.)