### PR TITLE
use old *_CMD style macro for commands.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ nsxiv: $(OBJS)
 	@echo "CC $@"
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
-$(OBJS): Makefile nsxiv.h config.h
+$(OBJS): Makefile nsxiv.h config.h commands.h
 options.o: version.h
 window.o: icon/data.h
 

--- a/commands.h
+++ b/commands.h
@@ -2,82 +2,48 @@
 #define COMMANDS_H
 #include <stdbool.h>
 
-/* global */
-bool cg_change_gamma();
-bool cg_first();
-bool cg_mark_range();
-bool cg_n_or_last();
-bool cg_navigate_marked();
-bool cg_prefix_external();
-bool cg_quit();
-bool cg_reload_image();
-bool cg_remove_image();
-bool cg_reverse_marks();
-bool cg_scroll_screen();
-bool cg_switch_mode();
-bool cg_toggle_bar();
-bool cg_toggle_fullscreen();
-bool cg_toggle_image_mark();
-bool cg_unmark_all();
-bool cg_zoom();
-/* image mode */
-bool ci_alternate();
-bool ci_cursor_navigate();
-bool ci_drag();
-bool ci_fit_to_win();
-bool ci_flip();
-bool ci_navigate();
-bool ci_navigate_frame();
-bool ci_rotate();
-bool ci_scroll();
-bool ci_scroll_to_edge();
-bool ci_set_zoom();
-bool ci_slideshow();
-bool ci_toggle_alpha();
-bool ci_toggle_animation();
-bool ci_toggle_antialias();
-/* thumbnails mode */
-bool ct_move_sel();
-bool ct_reload_all();
+#define G_CMD(c) bool cg_##c(arg_t); static const cmd_t g_##c = { cg_##c, MODE_ALL };
+#define I_CMD(c) bool ci_##c(arg_t); static const cmd_t i_##c = { ci_##c, MODE_IMAGE };
+#define T_CMD(c) bool ct_##c(arg_t); static const cmd_t t_##c = { ct_##c, MODE_THUMB };
 
 /* global */
-#define g_change_gamma { cg_change_gamma, MODE_ALL }
-#define g_first { cg_first, MODE_ALL }
-#define g_mark_range { cg_mark_range, MODE_ALL }
-#define g_n_or_last { cg_n_or_last, MODE_ALL }
-#define g_navigate_marked { cg_navigate_marked, MODE_ALL }
-#define g_prefix_external { cg_prefix_external, MODE_ALL }
-#define g_quit { cg_quit, MODE_ALL }
-#define g_reload_image { cg_reload_image, MODE_ALL }
-#define g_remove_image { cg_remove_image, MODE_ALL }
-#define g_reverse_marks { cg_reverse_marks, MODE_ALL }
-#define g_scroll_screen { cg_scroll_screen, MODE_ALL }
-#define g_switch_mode { cg_switch_mode, MODE_ALL }
-#define g_toggle_bar { cg_toggle_bar, MODE_ALL }
-#define g_toggle_fullscreen { cg_toggle_fullscreen, MODE_ALL }
-#define g_toggle_image_mark { cg_toggle_image_mark, MODE_ALL }
-#define g_unmark_all { cg_unmark_all, MODE_ALL }
-#define g_zoom { cg_zoom, MODE_ALL }
+G_CMD(change_gamma)
+G_CMD(first)
+G_CMD(mark_range)
+G_CMD(n_or_last)
+G_CMD(navigate_marked)
+G_CMD(prefix_external)
+G_CMD(quit)
+G_CMD(reload_image)
+G_CMD(remove_image)
+G_CMD(reverse_marks)
+G_CMD(scroll_screen)
+G_CMD(switch_mode)
+G_CMD(toggle_bar)
+G_CMD(toggle_fullscreen)
+G_CMD(toggle_image_mark)
+G_CMD(unmark_all)
+G_CMD(zoom)
 
 /* image mode */
-#define i_alternate { ci_alternate, MODE_IMAGE }
-#define i_cursor_navigate { ci_cursor_navigate, MODE_IMAGE }
-#define i_drag { ci_drag, MODE_IMAGE }
-#define i_fit_to_win { ci_fit_to_win, MODE_IMAGE }
-#define i_flip { ci_flip, MODE_IMAGE }
-#define i_navigate { ci_navigate, MODE_IMAGE }
-#define i_navigate_frame { ci_navigate_frame, MODE_IMAGE }
-#define i_rotate { ci_rotate, MODE_IMAGE }
-#define i_scroll { ci_scroll, MODE_IMAGE }
-#define i_scroll_to_edge { ci_scroll_to_edge, MODE_IMAGE }
-#define i_set_zoom { ci_set_zoom, MODE_IMAGE }
-#define i_slideshow { ci_slideshow, MODE_IMAGE }
-#define i_toggle_alpha { ci_toggle_alpha, MODE_IMAGE }
-#define i_toggle_animation { ci_toggle_animation, MODE_IMAGE }
-#define i_toggle_antialias { ci_toggle_antialias, MODE_IMAGE }
+I_CMD(alternate)
+I_CMD(cursor_navigate)
+I_CMD(drag)
+I_CMD(fit_to_win)
+I_CMD(flip)
+I_CMD(navigate)
+I_CMD(navigate_frame)
+I_CMD(rotate)
+I_CMD(scroll)
+I_CMD(scroll_to_edge)
+I_CMD(set_zoom)
+I_CMD(slideshow)
+I_CMD(toggle_alpha)
+I_CMD(toggle_animation)
+I_CMD(toggle_antialias)
 
 /* thumbnails mode */
-#define t_move_sel { ct_move_sel, MODE_THUMB }
-#define t_reload_all { ct_reload_all, MODE_THUMB }
+T_CMD(move_sel)
+T_CMD(reload_all)
 
 #endif

--- a/commands.h
+++ b/commands.h
@@ -1,7 +1,3 @@
-#ifndef COMMANDS_H
-#define COMMANDS_H
-#include <stdbool.h>
-
 #define G_CMD(c) bool cg_##c(arg_t); static const cmd_t g_##c = { cg_##c, MODE_ALL };
 #define I_CMD(c) bool ci_##c(arg_t); static const cmd_t i_##c = { ci_##c, MODE_IMAGE };
 #define T_CMD(c) bool ct_##c(arg_t); static const cmd_t t_##c = { ct_##c, MODE_THUMB };
@@ -45,5 +41,3 @@ I_CMD(toggle_antialias)
 /* thumbnails mode */
 T_CMD(move_sel)
 T_CMD(reload_all)
-
-#endif

--- a/commands.h
+++ b/commands.h
@@ -1,3 +1,6 @@
+#ifndef COMMANDS_H
+#define COMMANDS_H
+
 #define G_CMD(c) bool cg_##c(arg_t); static const cmd_t g_##c = { cg_##c, MODE_ALL };
 #define I_CMD(c) bool ci_##c(arg_t); static const cmd_t i_##c = { ci_##c, MODE_IMAGE };
 #define T_CMD(c) bool ct_##c(arg_t); static const cmd_t t_##c = { ct_##c, MODE_THUMB };
@@ -41,3 +44,5 @@ I_CMD(toggle_antialias)
 /* thumbnails mode */
 T_CMD(move_sel)
 T_CMD(reload_all)
+
+#endif /* COMMANDS_H */

--- a/main.c
+++ b/main.c
@@ -802,7 +802,7 @@ static void run(void)
 				break;
 			case ClientMessage:
 				if ((Atom) ev.xclient.data.l[0] == atoms[ATOM_WM_DELETE_WINDOW])
-					cg_quit(0);
+					cg_quit(None);
 				break;
 			case DestroyNotify:
 				exit(EXIT_FAILURE);

--- a/main.c
+++ b/main.c
@@ -802,7 +802,7 @@ static void run(void)
 				break;
 			case ClientMessage:
 				if ((Atom) ev.xclient.data.l[0] == atoms[ATOM_WM_DELETE_WINDOW])
-					cg_quit();
+					cg_quit(0);
 				break;
 			case DestroyNotify:
 				exit(EXIT_FAILURE);


### PR DESCRIPTION
there's a lot of repetition going on so using a macro makes sense.

two other thing this commit does is:

* specify the argument type in the function prototype compared to
  leaving it unspecified
* changes in command.h will now trigger a full rebuild.