### PR TITLE
'Automatic' way of setting a cache size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ PREFIX ?= /usr/local
 MANPREFIX ?= $(PREFIX)/share/man
 EGPREFIX ?= $(PREFIX)/share/doc/nsxiv/examples
 
+# default cache size
+DEFAULT_CACHE_SIZE=4
+
+# cache size being 0.000004 of your total ram (falls down to 4 if the number is lower than 4)
+AUTO_CACHE_SIZE=$(shell awk '/MemTotal/{size=$$2 * 0.000004; if (size < 4) print 4; else printf "%0.f\n", size;}' /proc/meminfo)
+
 # default value for optional dependencies. 1 = enabled, 0 = disabled
 OPT_DEP_DEFAULT ?= 1
 
@@ -30,6 +36,7 @@ inc_fonts_1 = -I/usr/include/freetype2 -I$(PREFIX)/include/freetype2
 CPPFLAGS = -D_XOPEN_SOURCE=700 \
   -DHAVE_LIBGIF=$(HAVE_LIBGIF) -DHAVE_LIBEXIF=$(HAVE_LIBEXIF) \
   -DHAVE_LIBWEBP=$(HAVE_LIBWEBP) -DHAVE_LIBFONTS=$(HAVE_LIBFONTS) \
+  -DDEFAULT_CACHE_SIZE=$(AUTO_CACHE_SIZE) \
   $(inc_fonts_$(HAVE_LIBFONTS))
 
 lib_fonts_0 =

--- a/config.def.h
+++ b/config.def.h
@@ -66,7 +66,7 @@ static const bool ALPHA_LAYER = false;
  * size is kept at 4MiB. For most users, it is advised to pick a value close to
  * or above 128MiB for better image (re)loading performance.
  */
-static const int CACHE_SIZE = 4 * 1024 * 1024; /* 4MiB */
+static const int CACHE_SIZE = DEFAULT_CACHE_SIZE * 1024 * 1024; /* 4MiB */
 
 #endif
 #ifdef _THUMBS_CONFIG


### PR DESCRIPTION
Had this idea that I wanted to share. Still a draft since I would prefer an option on the make file to calculate this like `make cachesize`. Also please suggest a different percentaje of the ram, whether to calculate this on `MemTotal` or `MemFree`, etc.