### PR TITLE
Calculate imlib2 cache size at runtime based on RAM size

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -64,7 +64,7 @@ static const bool ALPHA_LAYER = false;
 
 /* percentage of memory to use for imlib2's cache size.
  *   3 means use 3% of total memory which is about 245MiB on 8GiB machine.
- *   0 means disable cache
+ *   0 or less means disable cache.
  * 100 means use all available memory (but not above CACHE_SIZE_LIMIT).
  */
 static const int CACHE_SIZE_MEM_PERCENTAGE = 3;          /* use 3% of total memory for cache */

--- a/config.def.h
+++ b/config.def.h
@@ -63,9 +63,9 @@ static const bool ANTI_ALIAS = true;
 static const bool ALPHA_LAYER = false;
 
 /* percentage of memory to use for imlib2's cache size.
- *   0 means use imlib2's default 4MiB
- * 100 means use all available memory (but not above CACHE_SIZE_LIMIT).
  *   3 means use 3% of total memory which is about 245MiB on 8GiB machine.
+ *   0 means disable cache
+ * 100 means use all available memory (but not above CACHE_SIZE_LIMIT).
  */
 static const int CACHE_SIZE_MEM_PERCENTAGE = 3;          /* use 3% of total memory for cache */
 static const int CACHE_SIZE_LIMIT = 256 * 1024 * 1024;   /* but not above 256MiB */

--- a/config.def.h
+++ b/config.def.h
@@ -62,15 +62,14 @@ static const bool ANTI_ALIAS = true;
  */
 static const bool ALPHA_LAYER = false;
 
-/* size of cache used by imlib2 in % of RAM it is allowed to use.
- * from 0.0 (use ancient imlib2's default 4MiB) to 1.0 (all available, but not above CACHE_SIZE_LIMIT).
- * 3% is about 245MiB on 8GiB machine which should be good enough for most use cases.
+/* percentage of memory to use for imlib2's cache size.
+ *   0 means use imlib2's default 4MiB
+ * 100 means use all available memory (but not above CACHE_SIZE_LIMIT).
+ *   3 means use 3% of total memory which is about 245MiB on 8GiB machine.
  */
-static const float CACHE_SIZE_RAM_PERCENTAGE = 0.03; /* use 3% of RAM at max for cache */
-static const int CACHE_SIZE_LIMIT = 256 * 1024 * 1024; /* ...but not above 256MiB at max */
-
-/* if we can't determine total RAM - use cache of this size, 32MiB */
-static const int CACHE_SIZE_FALLBACK = 32 * 1024 * 1024;
+static const int CACHE_SIZE_MEM_PERCENTAGE = 3;          /* use 3% of total memory for cache */
+static const int CACHE_SIZE_LIMIT = 256 * 1024 * 1024;   /* but not above 256MiB */
+static const int CACHE_SIZE_FALLBACK = 32 * 1024 * 1024; /* fallback to 32MiB if we can't determine total memory */
 
 #endif
 #ifdef _THUMBS_CONFIG

--- a/config.def.h
+++ b/config.def.h
@@ -62,11 +62,11 @@ static const bool ANTI_ALIAS = true;
  */
 static const bool ALPHA_LAYER = false;
 
-/* cache size for imlib2, in bytes. For backwards compatibility reasons, the
- * size is kept at 4MiB. For most users, it is advised to pick a value close to
- * or above 128MiB for better image (re)loading performance.
+/* size of cache used by imlib2 in % of RAM it is allowed to use.
+ * from 0.0 (use ancient imlib2's default 4MiB) to 1.0 (all available).
+ * 3% is about 245MiB on 8GiB machine which should be good enough for most use cases.
  */
-static const int CACHE_SIZE = 4 * 1024 * 1024; /* 4MiB */
+static const float CACHE_SIZE_RAM_PERCENTAGE = 0.03; /* use 3% of RAM at max for cache */
 
 #endif
 #ifdef _THUMBS_CONFIG

--- a/config.def.h
+++ b/config.def.h
@@ -63,10 +63,14 @@ static const bool ANTI_ALIAS = true;
 static const bool ALPHA_LAYER = false;
 
 /* size of cache used by imlib2 in % of RAM it is allowed to use.
- * from 0.0 (use ancient imlib2's default 4MiB) to 1.0 (all available).
+ * from 0.0 (use ancient imlib2's default 4MiB) to 1.0 (all available, but not above CACHE_SIZE_LIMIT).
  * 3% is about 245MiB on 8GiB machine which should be good enough for most use cases.
  */
 static const float CACHE_SIZE_RAM_PERCENTAGE = 0.03; /* use 3% of RAM at max for cache */
+static const int CACHE_SIZE_LIMIT = 256 * 1024 * 1024; /* ...but not above 256MiB at max */
+
+/* if we can't determine total RAM - use cache of this size, 32MiB */
+static const int CACHE_SIZE_FALLBACK = 32 * 1024 * 1024;
 
 #endif
 #ifdef _THUMBS_CONFIG

--- a/image.c
+++ b/image.c
@@ -46,19 +46,20 @@ enum { DEF_WEBP_DELAY = 75 };
 static const float ZOOM_MIN = zoom_levels[0] / 100;
 static const float ZOOM_MAX = zoom_levels[ARRLEN(zoom_levels)-1] / 100;
 
-long long calc_cache_size() {
-	long pages = sysconf(_SC_PHYS_PAGES);
+static int calc_cache_size(void)
+{
+	long pages, page_size;
+	int cache;
 
-	if (pages < 0)
-		/* _SC_PHYS_PAGES is not supported / error / "indeterminate" */
+	pages = sysconf(_SC_PHYS_PAGES);
+	page_size = sysconf(_SC_PAGE_SIZE);
+	if (pages < 0 || page_size < 0)
 		return CACHE_SIZE_FALLBACK;
 
-	long page_size = sysconf(_SC_PAGE_SIZE);
-	long long total_ram = pages * page_size;
+	cache = pages * CACHE_SIZE_RAM_PERCENTAGE;
+	cache *= page_size;
 
-	/* long long down to int inside imlib2, don't run this on supercomputer, I guess */
-	long long for_cache = total_ram * CACHE_SIZE_RAM_PERCENTAGE;
-	return MIN(MAX(for_cache, 4 * 1024 * 1024), CACHE_SIZE_LIMIT);
+	return MIN(MAX(cache, 4 * 1024 * 1024), CACHE_SIZE_LIMIT);
 }
 
 void img_init(img_t *img, win_t *win)

--- a/image.c
+++ b/image.c
@@ -48,10 +48,10 @@ static const float ZOOM_MAX = zoom_levels[ARRLEN(zoom_levels)-1] / 100;
 
 static int calc_cache_size(void)
 {
-	long pages, page_size;
 	int cache;
+	long pages, page_size;
 
-	if (CACHE_SIZE_MEM_PERCENTAGE == 0)
+	if (CACHE_SIZE_MEM_PERCENTAGE <= 0)
 		return 0;
 
 	pages = sysconf(_SC_PHYS_PAGES);

--- a/image.c
+++ b/image.c
@@ -51,15 +51,17 @@ static int calc_cache_size(void)
 	long pages, page_size;
 	int cache;
 
+	if (CACHE_SIZE_MEM_PERCENTAGE == 0)
+		return 0;
+
 	pages = sysconf(_SC_PHYS_PAGES);
 	page_size = sysconf(_SC_PAGE_SIZE);
 	if (pages < 0 || page_size < 0)
 		return CACHE_SIZE_FALLBACK;
-
 	cache = (pages/100) * CACHE_SIZE_MEM_PERCENTAGE;
 	cache *= page_size;
 
-	return MIN(MAX(cache, 4 * 1024 * 1024), CACHE_SIZE_LIMIT);
+	return MIN(cache, CACHE_SIZE_LIMIT);
 }
 
 void img_init(img_t *img, win_t *win)

--- a/image.c
+++ b/image.c
@@ -48,12 +48,17 @@ static const float ZOOM_MAX = zoom_levels[ARRLEN(zoom_levels)-1] / 100;
 
 long long calc_cache_size() {
 	long pages = sysconf(_SC_PHYS_PAGES);
+
+	if (pages < 0)
+		/* _SC_PHYS_PAGES is not supported / error / "indeterminate" */
+		return CACHE_SIZE_FALLBACK;
+
 	long page_size = sysconf(_SC_PAGE_SIZE);
 	long long total_ram = pages * page_size;
 
 	/* long long down to int inside imlib2, don't run this on supercomputer, I guess */
 	long long for_cache = total_ram * CACHE_SIZE_RAM_PERCENTAGE;
-	return MAX(for_cache, 4 * 1024 * 1024);
+	return MIN(MAX(for_cache, 4 * 1024 * 1024), CACHE_SIZE_LIMIT);
 }
 
 void img_init(img_t *img, win_t *win)

--- a/image.c
+++ b/image.c
@@ -56,7 +56,7 @@ static int calc_cache_size(void)
 	if (pages < 0 || page_size < 0)
 		return CACHE_SIZE_FALLBACK;
 
-	cache = pages * CACHE_SIZE_RAM_PERCENTAGE;
+	cache = (pages/100) * CACHE_SIZE_MEM_PERCENTAGE;
 	cache *= page_size;
 
 	return MIN(MAX(cache, 4 * 1024 * 1024), CACHE_SIZE_LIMIT);

--- a/image.c
+++ b/image.c
@@ -46,12 +46,22 @@ enum { DEF_WEBP_DELAY = 75 };
 static const float ZOOM_MIN = zoom_levels[0] / 100;
 static const float ZOOM_MAX = zoom_levels[ARRLEN(zoom_levels)-1] / 100;
 
+long long calc_cache_size() {
+	long pages = sysconf(_SC_PHYS_PAGES);
+	long page_size = sysconf(_SC_PAGE_SIZE);
+	long long total_ram = pages * page_size;
+
+	/* long long down to int inside imlib2, don't run this on supercomputer, I guess */
+	long long for_cache = total_ram * CACHE_SIZE_RAM_PERCENTAGE;
+	return MAX(for_cache, 4 * 1024 * 1024);
+}
+
 void img_init(img_t *img, win_t *win)
 {
 	imlib_context_set_display(win->env.dpy);
 	imlib_context_set_visual(win->env.vis);
 	imlib_context_set_colormap(win->env.cmap);
-	imlib_set_cache_size(CACHE_SIZE);
+	imlib_set_cache_size(calc_cache_size());
 
 	img->im = NULL;
 	img->win = win;


### PR DESCRIPTION
Currently imlib2 cache size is set to 4 MiB, which is unreasonably low for most systems, and not that useful for most images.

Values like 128 or 256 MiB seem more appropriate and have noticeable performance benefits, but hardcoding them will negatively impact binary users on low RAM systems (such as raspberry pi) as been mentioned in #171 discussion.

This PR replaces `CACHE_SIZE` with 3 new constants:

* `CACHE_SIZE_RAM_PERCENTAGE = 0.03` - how much RAM nsxiv is allowed to use for imlib2 cache. Set to 3% of total RAM by default.
* `CACHE_SIZE_LIMIT = 256 * 1024 * 1024` - absolute maximum value in bytes it can't exceed, while honoring CACHE_SIZE_RAM_PERCENTAGE. Set to 256 MiB by default.
* `CACHE_SIZE_FALLBACK = 32 * 1024 * 1024` - what cache size to use when total RAM can't be determined. Set to 32 MiB by default.

Total RAM is calculated by multiplication of `sysconf(_SC_PAGE_SIZE)` (which is POSIX) and `sysconf(_SC_PHYS_PAGES)` (which isn't, but supported by Linux and FreeBSD - https://github.com/nsxiv/nsxiv/pull/171#issuecomment-986252585, and probably others)

If `_SC_PHYS_PAGES` is not supported - cache size is set to `CACHE_SIZE_FALLBACK` value.

That means:
* 16gb system will get 256 MiB cache
* 8gb system will get ~245 MiB cache
* 4gb system will get ~122 MiB cache
* 2gb system will get ~61 MiB cache
* 1gb system will get ~30 MiB cache
* 0.5gb system will get ~15 MiB cache
* 64 MiB system will get default 4MiB (or you could set `CACHE_SIZE_RAM_PERCENTAGE` to 0)