### PR TITLE
fix: exif orientation on Imlib2 v1.7.5 with jpeg

### DIFF
--- a/image.c
+++ b/image.c
@@ -425,7 +425,7 @@ bool img_load(img_t *img, const fileinfo_t *file)
  * this version also happens to be the first one which defines the
  * IMLIB2_VERSION macro.
  */
-#if defined(HAVE_LIBEXIF) && !defined(IMLIB2_VERSION)
+#if HAVE_LIBEXIF && !defined(IMLIB2_VERSION)
 	exif_auto_orientate(file);
 #endif
 
@@ -438,7 +438,7 @@ bool img_load(img_t *img, const fileinfo_t *file)
 		if (STREQ(fmt, "webp"))
 			img_load_webp(img, file);
 #endif
-#if defined(HAVE_LIBEXIF) && defined(IMLIB2_VERSION)
+#if HAVE_LIBEXIF && defined(IMLIB2_VERSION)
 		if (!STREQ(fmt, "jpeg") && !STREQ(fmt, "jpg"))
 			exif_auto_orientate(file);
 #endif

--- a/image.c
+++ b/image.c
@@ -421,11 +421,14 @@ bool img_load(img_t *img, const fileinfo_t *file)
 
 	imlib_image_set_changes_on_disk();
 
+	if ((fmt = imlib_image_format()) != NULL) {
 #if HAVE_LIBEXIF
-	exif_auto_orientate(file);
+		/* Imlib2 can handle jpeg exif orientation since v1.7.5 */
+		if ((IMLIB2_VERSION <= IMLIB2_VERSION_(1, 7, 4)) ||
+		    (!STREQ(fmt, "jpeg") && !STREQ(fmt, "jpg")))
+			exif_auto_orientate(file);
 #endif
 
-	if ((fmt = imlib_image_format()) != NULL) {
 #if HAVE_LIBGIF
 		if (STREQ(fmt, "gif"))
 			img_load_gif(img, file);


### PR DESCRIPTION
since Imlib2 v1.7.5, it is capable of parsing exif data on jpeg files
and auto orienting them. this caused nsxiv to rotate the image twice.

Closes: https://github.com/nsxiv/nsxiv/issues/187

---

I don't have images with exif, so I only tested on the example image attached on #187.