### PR TITLE
fix: reset statusbar after failed keyhandler

### DIFF
--- a/main.c
+++ b/main.c
@@ -602,7 +602,6 @@ end:
 	}
 	free(oldst);
 	reset_cursor();
-	redraw();
 	return true;
 }
 
@@ -646,7 +645,7 @@ static void on_keypress(XKeyEvent *kev)
 	if (extprefix && ksym == KEYHANDLER_ABORT && MODMASK(kev->state) == 0) {
 		handle_key_handler(false);
 	} else if (extprefix) {
-		if (run_key_handler(XKeysymToString(ksym), kev->state & ~sh))
+		if ((dirty = run_key_handler(XKeysymToString(ksym), kev->state & ~sh)))
 			extprefix = false;
 		else
 			handle_key_handler(false);


### PR DESCRIPTION
currently if the keyhandler invokation fails, for example due to it not
being present, the statusbar does not reset and stays on "getting
keyhandler input" message.

now the return value from run_key_handler() is used to determine if the
function was successful or not. and if the function failed, we call
handle_key_handler with false which resets the statusbar.