### PR TITLE
fix: broken compilation when using HAVE_LIBFONTS=0

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -89,7 +89,7 @@ static const KeySym KEYHANDLER_ABORT = XK_Escape;
 /* keyboard mappings for image and thumbnail mode: */
 static const keymap_t keys[] = {
 	/* modifiers    key               function              argument */
-	{ 0,            XK_q,             g_quit,               EXIT_SUCCESS },
+	{ 0,            XK_q,             g_quit,               0 },
 	{ 0,            XK_Return,        g_switch_mode,        None },
 	{ 0,            XK_f,             g_toggle_fullscreen,  None },
 	{ 0,            XK_b,             g_toggle_bar,         None },


### PR DESCRIPTION
compilation currently fails with `make HAVE_LIBFONTS=0` due to
`EXIT_SUCCESS` not being defined. I assume Xft.h includes stdlib.h which
is why compilation works with HAVE_LIBFONTS=1

this switches to using 0 as cg_quit argument in keybindings. if my
interpretation of the C99 standard is correct, then 0 and EXIT_SUCCESS
means the same thing.

> If the value of status is zero or EXIT_SUCCESS, an
> implementation-defined form of the status successful termination is
> returned.