### PR TITLE
add github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
         sudo apt-get install libimlib2 libimlib2-dev \
                              xserver-xorg-core xserver-xorg-dev \
                              libxft2 libxft-dev libexif12 libexif-dev \
-                             gcc clang
-        git clone 'git://repo.or.cz/tinycc.git'
+                             gcc clang >/dev/null
+        git clone 'git://repo.or.cz/tinycc.git' >/dev/null
         ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
         export OPT_DEP_DEFAULT=1
-        make clean && CC=gcc   make -s
-        make clean && CC=clang make -s
-        make clean && CC=tcc   make -s
+        make clean && echo "###  GCC BUILD  ###" && CC=gcc   make -s
+        make clean && echo "### CLANG BUILD ###" && CC=clang make -s
+        make clean && echo "###  TCC BUILD  ###" && CC=tcc   make -s
 
   minimal-build:
 
@@ -37,11 +37,11 @@ jobs:
       run: |
         sudo apt-get install libimlib2 libimlib2-dev \
                              xserver-xorg-core xserver-xorg-dev \
-                             gcc clang
-        sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev
-        git clone 'git://repo.or.cz/tinycc.git'
+                             gcc clang >/dev/null
+        sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev >/dev/null
+        git clone 'git://repo.or.cz/tinycc.git' >/dev/null
         ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
         export OPT_DEP_DEFAULT=0
-        make clean && CC=gcc   make -s
-        make clean && CC=clang make -s
-        make clean && CC=tcc   make -s
+        make clean && echo "###  GCC BUILD  ###" && CC=gcc   make -s
+        make clean && echo "### CLANG BUILD ###" && CC=clang make -s
+        make clean && echo "###  TCC BUILD  ###" && CC=tcc   make -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
         git clone --quiet 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
         export OPT_DEP_DEFAULT=1
-        make clean && echo "###  GCC BUILD  ###" && CC=gcc   make -s
-        make clean && echo "### CLANG BUILD ###" && CC=clang make -s
-        make clean && echo "###  TCC BUILD  ###" && CC=tcc   make -s
+        echo "###  GCC BUILD  ###" && make clean && CC=gcc   make -s
+        echo "### CLANG BUILD ###" && make clean && CC=clang make -s
+        echo "###  TCC BUILD  ###" && make clean && CC=tcc   make -s
 
   minimal-build:
     runs-on: ubuntu-latest
@@ -36,6 +36,6 @@ jobs:
         git clone --quiet 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
         export OPT_DEP_DEFAULT=0
-        make clean && echo "###  GCC BUILD  ###" && CC=gcc   make -s
-        make clean && echo "### CLANG BUILD ###" && CC=clang make -s
-        make clean && echo "###  TCC BUILD  ###" && CC=tcc   make -s
+        echo "###  GCC BUILD  ###" && make clean && CC=gcc   make -s
+        echo "### CLANG BUILD ###" && make clean && CC=clang make -s
+        echo "###  TCC BUILD  ###" && make clean && CC=tcc   make -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,78 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  gcc-full:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: |
+        sudo apt-get install libimlib2 libimlib2-dev libxft2 libxft-dev gcc
+        CC=gcc OPT_DEP_DEFAULT=1 make
+
+  gcc-minimal:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: |
+        sudo apt-get install libimlib2 libimlib2-dev gcc
+        sudo apt-get remove libxft2 libxft-dev
+        CC=gcc OPT_DEP_DEFAULT=0 make
+
+  clang-full:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: |
+        sudo apt-get install libimlib2 libimlib2-dev libxft2 libxft-dev clang
+        CC=clang OPT_DEP_DEFAULT=1 make
+
+  clang-minimal:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: |
+        sudo apt-get install libimlib2 libimlib2-dev clang
+        sudo apt-get remove libxft2 libxft-dev
+        CC=clang OPT_DEP_DEFAULT=0 make
+
+  # FIXME: tcc fails at linking "tcc: error: undefined symbol '__dso_handle'"
+  # tcc-full:
+
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: make
+  #     run: |
+  #       sudo apt-get install libimlib2 libimlib2-dev libxft2 libxft-dev tcc
+  #       CC=tcc OPT_DEP_DEFAULT=1 make
+
+  # tcc-minimal:
+
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: make
+  #     run: |
+  #       sudo apt-get install libimlib2 libimlib2-dev tcc
+  #       sudo apt-get remove libxft2 libxft-dev
+  #       CC=tcc OPT_DEP_DEFAULT=0 make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
         git clone 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; )
         export OPT_DEP_DEFAULT=1
-        export CFLAGS="-std=c99 -Wall -pedantic -Werror"
         make clean && CC=gcc   make
         make clean && CC=clang make
         make clean && CC=tcc   make
@@ -43,7 +42,6 @@ jobs:
         git clone 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; )
         export OPT_DEP_DEFAULT=0
-        export CFLAGS="-std=c99 -Wall -pedantic -Werror"
         make clean && CC=gcc   make
         make clean && CC=clang make
         make clean && CC=tcc   make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,26 +53,30 @@ jobs:
         sudo apt-get remove libxft2 libxft-dev
         CC=clang OPT_DEP_DEFAULT=0 make
 
-  # FIXME: tcc fails at linking "tcc: error: undefined symbol '__dso_handle'"
-  # tcc-full:
+  # NOTE: "stable" tcc is too old and fails at linking. instead using git version.
+  tcc-full:
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: make
-  #     run: |
-  #       sudo apt-get install libimlib2 libimlib2-dev libxft2 libxft-dev tcc
-  #       CC=tcc OPT_DEP_DEFAULT=1 make
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: |
+        sudo apt-get install libimlib2 libimlib2-dev libxft2 libxft-dev
+        git clone 'git://repo.or.cz/tinycc.git'
+        ( cd tinycc && ./configure && make && sudo make install; )
+        CC=tcc OPT_DEP_DEFAULT=1 make
 
-  # tcc-minimal:
+  tcc-minimal:
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: make
-  #     run: |
-  #       sudo apt-get install libimlib2 libimlib2-dev tcc
-  #       sudo apt-get remove libxft2 libxft-dev
-  #       CC=tcc OPT_DEP_DEFAULT=0 make
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: |
+        sudo apt-get install libimlib2 libimlib2-dev
+        sudo apt-get remove libxft2 libxft-dev
+        git clone 'git://repo.or.cz/tinycc.git'
+        ( cd tinycc && ./configure && make && sudo make install; )
+        CC=tcc OPT_DEP_DEFAULT=0 make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        sudo apt-get install libimlib2 libimlib2-dev \
-                             xserver-xorg-core xserver-xorg-dev \
+        sudo apt-get install libimlib2 libimlib2-dev xserver-xorg-core xserver-xorg-dev \
                              libxft2 libxft-dev libexif12 libexif-dev \
                              gcc clang >/dev/null
         git clone --quiet 'git://repo.or.cz/tinycc.git'
@@ -31,8 +30,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        sudo apt-get install libimlib2 libimlib2-dev \
-                             xserver-xorg-core xserver-xorg-dev \
+        sudo apt-get install libimlib2 libimlib2-dev xserver-xorg-core xserver-xorg-dev \
                              gcc clang >/dev/null
         sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev >/dev/null
         git clone --quiet 'git://repo.or.cz/tinycc.git'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
                              xserver-xorg-core xserver-xorg-dev \
                              libxft2 libxft-dev libexif12 libexif-dev \
                              gcc clang >/dev/null
-        git clone 'git://repo.or.cz/tinycc.git' >/dev/null
+        git clone --quiet 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
         export OPT_DEP_DEFAULT=1
         make clean && echo "###  GCC BUILD  ###" && CC=gcc   make -s
@@ -39,7 +39,7 @@ jobs:
                              xserver-xorg-core xserver-xorg-dev \
                              gcc clang >/dev/null
         sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev >/dev/null
-        git clone 'git://repo.or.cz/tinycc.git' >/dev/null
+        git clone --quiet 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
         export OPT_DEP_DEFAULT=0
         make clean && echo "###  GCC BUILD  ###" && CC=gcc   make -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ jobs:
                              libxft2 libxft-dev libexif12 libexif-dev \
                              gcc clang
         git clone 'git://repo.or.cz/tinycc.git'
-        ( cd tinycc && ./configure && make && sudo make install; )
+        ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
         export OPT_DEP_DEFAULT=1
-        make clean && CC=gcc   make
-        make clean && CC=clang make
-        make clean && CC=tcc   make
+        make clean && CC=gcc   make -s
+        make clean && CC=clang make -s
+        make clean && CC=tcc   make -s
 
   minimal-build:
 
@@ -40,8 +40,8 @@ jobs:
                              gcc clang
         sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev
         git clone 'git://repo.or.cz/tinycc.git'
-        ( cd tinycc && ./configure && make && sudo make install; )
+        ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
         export OPT_DEP_DEFAULT=0
-        make clean && CC=gcc   make
-        make clean && CC=clang make
-        make clean && CC=tcc   make
+        make clean && CC=gcc   make -s
+        make clean && CC=clang make -s
+        make clean && CC=tcc   make -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+# NOTE: "stable" tcc is too old and fails at linking. instead using git version.
 jobs:
-  gcc-full:
+  full-build:
 
     runs-on: ubuntu-latest
 
@@ -18,68 +19,15 @@ jobs:
         sudo apt-get install libimlib2 libimlib2-dev \
                              xserver-xorg-core xserver-xorg-dev \
                              libxft2 libxft-dev libexif12 libexif-dev \
-                             gcc
-        CC=gcc OPT_DEP_DEFAULT=1 make
-
-  gcc-minimal:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: make
-      run: |
-        sudo apt-get install libimlib2 libimlib2-dev \
-                             xserver-xorg-core xserver-xorg-dev \
-                             gcc
-        sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev
-        CC=gcc OPT_DEP_DEFAULT=0 make
-
-  clang-full:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: make
-      run: |
-        sudo apt-get install libimlib2 libimlib2-dev \
-                             xserver-xorg-core xserver-xorg-dev \
-                             libxft2 libxft-dev libexif12 libexif-dev \
-                             clang
-        CC=clang OPT_DEP_DEFAULT=1 make
-
-  clang-minimal:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: make
-      run: |
-        sudo apt-get install libimlib2 libimlib2-dev \
-                             xserver-xorg-core xserver-xorg-dev \
-                             clang
-        sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev
-        CC=clang OPT_DEP_DEFAULT=0 make
-
-  # NOTE: "stable" tcc is too old and fails at linking. instead using git version.
-  tcc-full:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: make
-      run: |
-        sudo apt-get install libimlib2 libimlib2-dev \
-                             xserver-xorg-core xserver-xorg-dev \
-                             libxft2 libxft-dev libexif12 libexif-dev
+                             gcc clang
         git clone 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; )
-        CC=tcc OPT_DEP_DEFAULT=1 make
+        export OPT_DEP_DEFAULT=1
+        make clean && CC=gcc   make
+        make clean && CC=clang make
+        make clean && CC=tcc   make
 
-  tcc-minimal:
+  minimal-build:
 
     runs-on: ubuntu-latest
 
@@ -88,8 +36,12 @@ jobs:
     - name: make
       run: |
         sudo apt-get install libimlib2 libimlib2-dev \
-                             xserver-xorg-core xserver-xorg-dev
+                             xserver-xorg-core xserver-xorg-dev \
+                             gcc clang
         sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev
         git clone 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; )
-        CC=tcc OPT_DEP_DEFAULT=0 make
+        export OPT_DEP_DEFAULT=0
+        make clean && CC=gcc   make
+        make clean && CC=clang make
+        make clean && CC=tcc   make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         sudo apt-get install libimlib2 libimlib2-dev xserver-xorg-core xserver-xorg-dev \
                              libxft2 libxft-dev libexif12 libexif-dev \
                              gcc clang >/dev/null
-        git clone --quiet 'git://repo.or.cz/tinycc.git'
+        git clone --quiet --depth 1 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
         export OPT_DEP_DEFAULT=1
         echo "###  GCC BUILD  ###" && make clean && CC=gcc   make -s
@@ -33,7 +33,7 @@ jobs:
         sudo apt-get install libimlib2 libimlib2-dev xserver-xorg-core xserver-xorg-dev \
                              gcc clang >/dev/null
         sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev >/dev/null
-        git clone --quiet 'git://repo.or.cz/tinycc.git'
+        git clone --quiet --depth 1 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
         export OPT_DEP_DEFAULT=0
         echo "###  GCC BUILD  ###" && make clean && CC=gcc   make -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         git clone 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; )
         export OPT_DEP_DEFAULT=1
+        export CFLAGS="-std=c99 -Wall -pedantic -Werror"
         make clean && CC=gcc   make
         make clean && CC=clang make
         make clean && CC=tcc   make
@@ -42,6 +43,7 @@ jobs:
         git clone 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; )
         export OPT_DEP_DEFAULT=0
+        export CFLAGS="-std=c99 -Wall -pedantic -Werror"
         make clean && CC=gcc   make
         make clean && CC=clang make
         make clean && CC=tcc   make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,7 @@ on:
 # NOTE: "stable" tcc is too old and fails at linking. instead using git version.
 jobs:
   full-build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: make
@@ -28,9 +26,7 @@ jobs:
         make clean && echo "###  TCC BUILD  ###" && CC=tcc   make -s
 
   minimal-build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        sudo apt-get install libimlib2 libimlib2-dev libxft2 libxft-dev gcc
+        sudo apt-get install libimlib2 libimlib2-dev \
+                             xserver-xorg-core xserver-xorg-dev \
+                             libxft2 libxft-dev libexif12 libexif-dev \
+                             gcc
         CC=gcc OPT_DEP_DEFAULT=1 make
 
   gcc-minimal:
@@ -26,8 +29,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        sudo apt-get install libimlib2 libimlib2-dev gcc
-        sudo apt-get remove libxft2 libxft-dev
+        sudo apt-get install libimlib2 libimlib2-dev \
+                             xserver-xorg-core xserver-xorg-dev \
+                             gcc
+        sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev
         CC=gcc OPT_DEP_DEFAULT=0 make
 
   clang-full:
@@ -38,7 +43,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        sudo apt-get install libimlib2 libimlib2-dev libxft2 libxft-dev clang
+        sudo apt-get install libimlib2 libimlib2-dev \
+                             xserver-xorg-core xserver-xorg-dev \
+                             libxft2 libxft-dev libexif12 libexif-dev \
+                             clang
         CC=clang OPT_DEP_DEFAULT=1 make
 
   clang-minimal:
@@ -49,8 +57,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        sudo apt-get install libimlib2 libimlib2-dev clang
-        sudo apt-get remove libxft2 libxft-dev
+        sudo apt-get install libimlib2 libimlib2-dev \
+                             xserver-xorg-core xserver-xorg-dev \
+                             clang
+        sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev
         CC=clang OPT_DEP_DEFAULT=0 make
 
   # NOTE: "stable" tcc is too old and fails at linking. instead using git version.
@@ -62,7 +72,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        sudo apt-get install libimlib2 libimlib2-dev libxft2 libxft-dev
+        sudo apt-get install libimlib2 libimlib2-dev \
+                             xserver-xorg-core xserver-xorg-dev \
+                             libxft2 libxft-dev libexif12 libexif-dev
         git clone 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; )
         CC=tcc OPT_DEP_DEFAULT=1 make
@@ -75,8 +87,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: make
       run: |
-        sudo apt-get install libimlib2 libimlib2-dev
-        sudo apt-get remove libxft2 libxft-dev
+        sudo apt-get install libimlib2 libimlib2-dev \
+                             xserver-xorg-core xserver-xorg-dev
+        sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev
         git clone 'git://repo.or.cz/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; )
         CC=tcc OPT_DEP_DEFAULT=0 make


### PR DESCRIPTION
this runs both default and minimal build with gcc and clang.
tcc seems to fail at link time for some reason.

---

I'm not familiar with github actions/workflow, simply hacked this together from the provided template. Seems to be working fine, here's some example:

* https://github.com/N-R-K/nsxiv/runs/4614439272?check_suite_focus=true <br> (minimal build failing due to `EXIT_SUCCESS` not being defined)
* https://github.com/N-R-K/nsxiv/pull/2 <br> (PR fixing it)
