### PR TITLE
Add additional warning flags in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: make
+    - name: dep
       run: |
         sudo apt-get install libimlib2 libimlib2-dev xserver-xorg-core xserver-xorg-dev \
                              libxft2 libxft-dev libexif12 libexif-dev \
-                             gcc clang >/dev/null
+                             gcc clang
         TCC_SHA="027b8fb9b88fe137447fb8bb1b61079be9702472"
-        wget --quiet "https://github.com/TinyCC/tinycc/archive/${TCC_SHA}.tar.gz" && tar xzf "${TCC_SHA}.tar.gz"
-        ( cd "tinycc-$TCC_SHA" && ./configure && make && sudo make install; ) >/dev/null
+        wget "https://github.com/TinyCC/tinycc/archive/${TCC_SHA}.tar.gz" && tar xzf "${TCC_SHA}.tar.gz"
+        ( cd "tinycc-$TCC_SHA" && ./configure && make && sudo make install; )
+    - name: build
+      run: |
         # vanilla flags
         CFLAGS="-std=c99 -Wall -pedantic"
         # extra flags
@@ -38,14 +40,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: make
+    - name: dep
       run: |
         sudo apt-get install libimlib2 libimlib2-dev xserver-xorg-core xserver-xorg-dev \
-                             gcc clang >/dev/null
-        sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev >/dev/null
+                             gcc clang
+        sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev
         TCC_SHA="027b8fb9b88fe137447fb8bb1b61079be9702472"
-        wget --quiet "https://github.com/TinyCC/tinycc/archive/${TCC_SHA}.tar.gz" && tar xzf "${TCC_SHA}.tar.gz"
-        ( cd "tinycc-$TCC_SHA" && ./configure && make && sudo make install; ) >/dev/null
+        wget "https://github.com/TinyCC/tinycc/archive/${TCC_SHA}.tar.gz" && tar xzf "${TCC_SHA}.tar.gz"
+        ( cd "tinycc-$TCC_SHA" && ./configure && make && sudo make install; )
+    - name: build
+      run: |
         # vanilla flags
         CFLAGS="-std=c99 -Wall -pedantic"
         # extra flags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,15 @@ jobs:
                              gcc clang >/dev/null
         git clone --quiet --depth 1 'https://github.com/TinyCC/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
+        # vanilla flags
+        CFLAGS="-std=c99 -Wall -pedantic"
+        # extra flags
+        CFLAGS+=" -Werror -Wextra -Wshadow -Wvla -Wpointer-arith -Wstrict-prototypes"
+        CFLAGS+=" -Wundef -Wstrict-overflow=4 -Wwrite-strings -Wunreachable-code"
+        CFLAGS+=" -Wbad-function-cast -Wdeclaration-after-statement"
+        # silence
+        CFLAGS+=" -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers"
+        export CFLAGS
         export OPT_DEP_DEFAULT=1
         echo "###  GCC BUILD  ###" && make clean && CC=gcc   make -s
         echo "### CLANG BUILD ###" && make clean && CC=clang make -s
@@ -35,6 +44,15 @@ jobs:
         sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev >/dev/null
         git clone --quiet --depth 1 'https://github.com/TinyCC/tinycc.git'
         ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
+        # vanilla flags
+        CFLAGS="-std=c99 -Wall -pedantic"
+        # extra flags
+        CFLAGS+=" -Werror -Wextra -Wshadow -Wvla -Wpointer-arith -Wstrict-prototypes"
+        CFLAGS+=" -Wundef -Wstrict-overflow=4 -Wwrite-strings -Wunreachable-code"
+        CFLAGS+=" -Wbad-function-cast -Wdeclaration-after-statement"
+        # silence
+        CFLAGS+=" -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers"
+        export CFLAGS
         export OPT_DEP_DEFAULT=0
         echo "###  GCC BUILD  ###" && make clean && CC=gcc   make -s
         echo "### CLANG BUILD ###" && make clean && CC=clang make -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ master ]
 
-# NOTE: "stable" tcc is too old and fails at linking. instead using git version.
+# NOTE: "stable" tcc is too old and fails at linking. instead fetching a recent known working commit.
 jobs:
   full-build:
     runs-on: ubuntu-latest
@@ -17,8 +17,9 @@ jobs:
         sudo apt-get install libimlib2 libimlib2-dev xserver-xorg-core xserver-xorg-dev \
                              libxft2 libxft-dev libexif12 libexif-dev \
                              gcc clang >/dev/null
-        git clone --quiet --depth 1 'https://github.com/TinyCC/tinycc.git'
-        ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
+        TCC_SHA="027b8fb9b88fe137447fb8bb1b61079be9702472"
+        wget --quiet "https://github.com/TinyCC/tinycc/archive/${TCC_SHA}.tar.gz" && tar xzf "${TCC_SHA}.tar.gz"
+        ( cd "tinycc-$TCC_SHA" && ./configure && make && sudo make install; ) >/dev/null
         # vanilla flags
         CFLAGS="-std=c99 -Wall -pedantic"
         # extra flags
@@ -42,8 +43,9 @@ jobs:
         sudo apt-get install libimlib2 libimlib2-dev xserver-xorg-core xserver-xorg-dev \
                              gcc clang >/dev/null
         sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev >/dev/null
-        git clone --quiet --depth 1 'https://github.com/TinyCC/tinycc.git'
-        ( cd tinycc && ./configure && make && sudo make install; ) >/dev/null
+        TCC_SHA="027b8fb9b88fe137447fb8bb1b61079be9702472"
+        wget --quiet "https://github.com/TinyCC/tinycc/archive/${TCC_SHA}.tar.gz" && tar xzf "${TCC_SHA}.tar.gz"
+        ( cd "tinycc-$TCC_SHA" && ./configure && make && sudo make install; ) >/dev/null
         # vanilla flags
         CFLAGS="-std=c99 -Wall -pedantic"
         # extra flags

--- a/commands.c
+++ b/commands.c
@@ -328,7 +328,7 @@ bool ci_scroll_to_edge(arg_t dir)
 	return img_pan_edge(&img, dir);
 }
 
-bool ci_drag(arg_t mode)
+bool ci_drag(arg_t drag_mode)
 {
 	int x, y, ox, oy;
 	float px, py;
@@ -337,13 +337,13 @@ bool ci_drag(arg_t mode)
 	if ((int)(img.w * img.zoom) <= win.w && (int)(img.h * img.zoom) <= win.h)
 		return false;
 
-	win_set_cursor(&win, mode == DRAG_ABSOLUTE ? CURSOR_DRAG_ABSOLUTE : CURSOR_DRAG_RELATIVE);
+	win_set_cursor(&win, drag_mode == DRAG_ABSOLUTE ? CURSOR_DRAG_ABSOLUTE : CURSOR_DRAG_RELATIVE);
 	win_cursor_pos(&win, &x, &y);
 	ox = x;
 	oy = y;
 
 	while (true) {
-		if (mode == DRAG_ABSOLUTE) {
+		if (drag_mode == DRAG_ABSOLUTE) {
 			px = MIN(MAX(0.0, x - win.w*0.1), win.w*0.8) / (win.w*0.8)
 			   * (win.w - img.w * img.zoom);
 			py = MIN(MAX(0.0, y - win.h*0.1), win.h*0.8) / (win.h*0.8)

--- a/commands.c
+++ b/commands.c
@@ -63,6 +63,7 @@ bool cg_quit(arg_t status)
 		}
 	}
 	exit(status);
+	return None; /* silence tcc warning */
 }
 
 bool cg_switch_mode(arg_t _)

--- a/commands.h
+++ b/commands.h
@@ -35,7 +35,7 @@ bool ci_set_zoom(arg_t);
 bool ci_slideshow(arg_t);
 bool ci_toggle_alpha(arg_t);
 bool ci_toggle_animation(arg_t);
-bool ci_toggle_antialias();
+bool ci_toggle_antialias(arg_t);
 /* thumbnails mode */
 bool ct_move_sel(arg_t);
 bool ct_reload_all(arg_t);

--- a/image.c
+++ b/image.c
@@ -141,7 +141,7 @@ static bool img_load_gif(img_t *img, const fileinfo_t *file)
 	GifRowType *rows = NULL;
 	GifRecordType rec;
 	ColorMapObject *cmap;
-	DATA32 bgpixel, *data, *ptr;
+	DATA32 bgpixel = 0, *data, *ptr;
 	DATA32 *prev_frame = NULL;
 	Imlib_Image im;
 	int i, j, bg, r, g, b;

--- a/image.c
+++ b/image.c
@@ -533,7 +533,6 @@ void img_render(img_t *img)
 	int sx, sy, sw, sh;
 	int dx, dy, dw, dh;
 	Imlib_Image bg;
-	XColor c;
 
 	win = img->win;
 	img_fit(img);
@@ -601,7 +600,7 @@ void img_render(img_t *img)
 			}
 			imlib_image_put_back_data(data);
 		} else {
-			c = win->win_bg;
+			XColor c = win->win_bg;
 			imlib_context_set_color(c.red >> 8, c.green >> 8, c.blue >> 8, 0xFF);
 			imlib_image_fill_rectangle(0, 0, dw, dh);
 		}

--- a/main.c
+++ b/main.c
@@ -605,19 +605,19 @@ end:
 	redraw();
 }
 
-static bool process_bindings(const keymap_t *keys, unsigned int len, KeySym ksym_or_button,
+static bool process_bindings(const keymap_t *bindings, unsigned int len, KeySym ksym_or_button,
                              unsigned int state, unsigned int implicit_mod)
 {
 	unsigned int i;
 	bool dirty = false;
 
 	for (i = 0; i < len; i++) {
-		if (keys[i].ksym_or_button == ksym_or_button &&
-		    MODMASK(keys[i].mask | implicit_mod) == MODMASK(state) &&
-		    keys[i].cmd.func &&
-		    (keys[i].cmd.mode == MODE_ALL || keys[i].cmd.mode == mode))
+		if (bindings[i].ksym_or_button == ksym_or_button &&
+		    MODMASK(bindings[i].mask | implicit_mod) == MODMASK(state) &&
+		    bindings[i].cmd.func &&
+		    (bindings[i].cmd.mode == MODE_ALL || bindings[i].cmd.mode == mode))
 		{
-			if (keys[i].cmd.func(keys[i].arg))
+			if (bindings[i].cmd.func(bindings[i].arg))
 				dirty = true;
 		}
 	}

--- a/window.c
+++ b/window.c
@@ -186,6 +186,8 @@ void win_open(win_t *win)
 	pid_t pid;
 	char hostname[256];
 	XSetWindowAttributes attrs;
+	char res_class[] = RES_CLASS;
+	char res_name[] = "nsxiv";
 
 	e = &win->env;
 	parent = options->embed ? options->embed : RootWindow(e->dpy, e->scr);
@@ -284,11 +286,11 @@ void win_open(win_t *win)
 	free(icon_data);
 
 	/* These two atoms won't change and thus only need to be set once. */
-	XStoreName(win->env.dpy, win->xwin, "nsxiv");
-	XSetIconName(win->env.dpy, win->xwin, "nsxiv");
+	XStoreName(win->env.dpy, win->xwin, res_name);
+	XSetIconName(win->env.dpy, win->xwin, res_name);
 
-	classhint.res_class = RES_CLASS;
-	classhint.res_name = options->res_name != NULL ? options->res_name : "nsxiv";
+	classhint.res_class = res_class;
+	classhint.res_name = options->res_name != NULL ? options->res_name : res_name;
 	XSetClassHint(e->dpy, win->xwin, &classhint);
 
 	XSetWMProtocols(e->dpy, win->xwin, &atoms[ATOM_WM_DELETE_WINDOW], 1);


### PR DESCRIPTION
fixes all -Wshadow related warnings (on gcc). this would allow us to use
`-Wshadow` in github workflow (https://github.com/nsxiv/nsxiv/pull/195).

i've thought about adding `-Wshadow` to our Makefile as well, but
decided against it to keep the Makefile CFLAGS barebore/minimal.