### PR TITLE
remove unused function and typedef

### DIFF
--- a/nsxiv.h
+++ b/nsxiv.h
@@ -56,11 +56,6 @@
 }
 
 typedef enum {
-	BO_BIG_ENDIAN,
-	BO_LITTLE_ENDIAN
-} byteorder_t;
-
-typedef enum {
 	MODE_ALL,
 	MODE_IMAGE,
 	MODE_THUMB
@@ -352,7 +347,6 @@ void* emalloc(size_t);
 void* erealloc(void*, size_t);
 char* estrdup(const char*);
 void error(int, int, const char*, ...);
-void size_readable(float*, const char**);
 int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*, bool);

--- a/util.c
+++ b/util.c
@@ -79,16 +79,6 @@ void error(int eval, int err, const char* fmt, ...)
 		exit(eval);
 }
 
-void size_readable(float *size, const char **unit)
-{
-	const char *units[] = { "", "K", "M", "G" };
-	unsigned int i;
-
-	for (i = 0; i < ARRLEN(units) && *size > 1024.0; i++)
-		*size /= 1024.0;
-	*unit = units[MIN(i, ARRLEN(units) - 1)];
-}
-
 int r_opendir(r_dir_t *rdir, const char *dirname, bool recursive)
 {
 	if (*dirname == '\0')


### PR DESCRIPTION
byteorder_t and size_readable is not used anywhere within the code.
however, i haven't tracked down where they were introduced or where they
became irrelevant.