### PR TITLE
fix: animation slowdown when zoomed in

### DIFF
--- a/main.c
+++ b/main.c
@@ -470,8 +470,8 @@ void reset_cursor(void)
 void animate(void)
 {
 	if (img_frame_animate(&img)) {
-		redraw();
 		set_timeout(animate, img.multi.frames[img.multi.sel].delay, true);
+		redraw();
 	}
 }
 


### PR DESCRIPTION
rendering is a pretty expensive operation, especially when scaling with
anti-aliasing. by waiting for the image to render before setting
timeout, the actual timeout ends up being (render time + actual delay).

this pretty much fixes the slowdown entirely on all the images i've
tested. it should also improve things noticeably even in cases where
the delay between frames is shorter than how fast we can render.
although on such images, the issue may not be fixed entirely.

Closes: https://github.com/nsxiv/nsxiv/issues/70