### PR TITLE
Add keybind to scroll to image center

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -325,6 +325,11 @@ bool ci_scroll(arg_t dir)
 	return img_pan(&img, dir, prefix);
 }
 
+bool ci_scroll_to_center(arg_t _)
+{
+	return img_pan_center(&img);
+}
+
 bool ci_scroll_to_edge(arg_t dir)
 {
 	return img_pan_edge(&img, dir);

--- a/commands.h
+++ b/commands.h
@@ -30,6 +30,7 @@ bool ci_navigate(arg_t);
 bool ci_navigate_frame(arg_t);
 bool ci_rotate(arg_t);
 bool ci_scroll(arg_t);
+bool ci_scroll_to_center(arg_t);
 bool ci_scroll_to_edge(arg_t);
 bool ci_set_zoom(arg_t);
 bool ci_slideshow(arg_t);
@@ -72,6 +73,7 @@ bool ct_select(arg_t);
 #define i_navigate_frame { ci_navigate_frame, MODE_IMAGE }
 #define i_rotate { ci_rotate, MODE_IMAGE }
 #define i_scroll { ci_scroll, MODE_IMAGE }
+#define i_scroll_to_center { ci_scroll_to_center, MODE_IMAGE }
 #define i_scroll_to_edge { ci_scroll_to_edge, MODE_IMAGE }
 #define i_set_zoom { ci_set_zoom, MODE_IMAGE }
 #define i_slideshow { ci_slideshow, MODE_IMAGE }

--- a/config.def.h
+++ b/config.def.h
@@ -158,7 +158,7 @@ static const keymap_t keys[] = {
 	{ 0,            XK_J,             i_scroll_to_edge,     DIR_DOWN },
 	{ 0,            XK_K,             i_scroll_to_edge,     DIR_UP },
 	{ 0,            XK_L,             i_scroll_to_edge,     DIR_RIGHT },
-	{ 0,            XK_c,             i_scroll_to_center,   None },
+	{ 0,            XK_z,             i_scroll_to_center,   None },
 	{ 0,            XK_equal,         i_set_zoom,           100 },
 	{ 0,            XK_w,             i_fit_to_win,         SCALE_DOWN },
 	{ 0,            XK_W,             i_fit_to_win,         SCALE_FIT },

--- a/config.def.h
+++ b/config.def.h
@@ -158,6 +158,7 @@ static const keymap_t keys[] = {
 	{ 0,            XK_J,             i_scroll_to_edge,     DIR_DOWN },
 	{ 0,            XK_K,             i_scroll_to_edge,     DIR_UP },
 	{ 0,            XK_L,             i_scroll_to_edge,     DIR_RIGHT },
+	{ 0,            XK_c,             i_scroll_to_center,   None },
 	{ 0,            XK_equal,         i_set_zoom,           100 },
 	{ 0,            XK_w,             i_fit_to_win,         SCALE_DOWN },
 	{ 0,            XK_W,             i_fit_to_win,         SCALE_FIT },

--- a/image.c
+++ b/image.c
@@ -744,6 +744,14 @@ bool img_pan(img_t *img, direction_t dir, int d)
 	return false;
 }
 
+bool img_pan_center(img_t *img)
+{
+	float x, y;
+	x = (img->win->w - img->w * img->zoom) / 2.0;
+	y = (img->win->h - img->h * img->zoom) / 2.0;
+	return img_pos(img, x, y);
+}
+
 bool img_pan_edge(img_t *img, direction_t dir)
 {
 	float ox, oy;

--- a/nsxiv.1
+++ b/nsxiv.1
@@ -318,6 +318,9 @@ Scroll to top image edge.
 .B L
 Scroll to right image edge.
 .TP
+.B c
+Scroll to image center.
+.TP
 Zooming:
 .TP
 .B =

--- a/nsxiv.1
+++ b/nsxiv.1
@@ -318,7 +318,7 @@ Scroll to top image edge.
 .B L
 Scroll to right image edge.
 .TP
-.B c
+.B z
 Scroll to image center.
 .TP
 Zooming:

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -229,6 +229,7 @@ bool img_zoom(img_t*, int);
 bool img_zoom_to(img_t*, float);
 bool img_pos(img_t*, float, float);
 bool img_pan(img_t*, direction_t, int);
+bool img_pan_center(img_t*);
 bool img_pan_edge(img_t*, direction_t);
 void img_rotate(img_t*, degree_t);
 void img_flip(img_t*, flipdir_t);


### PR DESCRIPTION
There are keybinds for scrolling to the edges of an image but there's no way back to the center. This is particularly annoying while zooming.