### PR TITLE
allow n and p to also be used for navigation in thumbnail mode

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -125,12 +125,14 @@ static const keymap_t keys[] = {
 
 	{ 0,            XK_h,             t_move_sel,           DIR_LEFT },
 	{ 0,            XK_Left,          t_move_sel,           DIR_LEFT },
+	{ 0,            XK_p,             t_move_sel,           DIR_LEFT },
 	{ 0,            XK_j,             t_move_sel,           DIR_DOWN },
 	{ 0,            XK_Down,          t_move_sel,           DIR_DOWN },
 	{ 0,            XK_k,             t_move_sel,           DIR_UP },
 	{ 0,            XK_Up,            t_move_sel,           DIR_UP },
 	{ 0,            XK_l,             t_move_sel,           DIR_RIGHT },
 	{ 0,            XK_Right,         t_move_sel,           DIR_RIGHT },
+	{ 0,            XK_n,             t_move_sel,           DIR_RIGHT },
 	{ 0,            XK_R,             t_reload_all,         None },
 
 	{ 0,            XK_n,             i_navigate,           +1 },


### PR DESCRIPTION
Since `n` and `p` aren't bound to anything in thumbnail mode, it seems like they should be used for the same functions that they have in image mode.