### PR TITLE
Add reuseable abstraction over fork/exec/dup2

### DIFF
--- a/main.c
+++ b/main.c
@@ -242,7 +242,7 @@ void open_info(void)
 {
 	xpopen_t pfd;
 	char w[12], h[12];
-	const char *argv[5];
+	char *argv[5];
 
 	if (info.f.err || info.fd >= 0 || win.bar.h == 0)
 		return;
@@ -250,7 +250,7 @@ void open_info(void)
 	snprintf(w, sizeof(w), "%d", img.w);
 	snprintf(h, sizeof(h), "%d", img.h);
 	argv[0] = info.f.cmd;
-	argv[1] = files[fileidx].path;
+	argv[1] = (char *)files[fileidx].path;
 	argv[2] = w;
 	argv[3] = h;
 	argv[4] = NULL;
@@ -516,7 +516,7 @@ static bool run_key_handler(const char *key, unsigned int mask)
 	char kstr[32];
 	struct stat *oldst, st;
 	XEvent dump;
-	const char *argv[3];
+	char *argv[3];
 	xpopen_t pfd;
 
 	if (keyhandler.f.err) {

--- a/main.c
+++ b/main.c
@@ -250,7 +250,7 @@ void open_info(void)
 	snprintf(w, sizeof(w), "%d", img.w);
 	snprintf(h, sizeof(h), "%d", img.h);
 	argv[0] = info.f.cmd;
-	argv[1] = (char *)files[fileidx].path;
+	argv[1] = (char *)files[fileidx].name;
 	argv[2] = w;
 	argv[3] = h;
 	argv[4] = NULL;

--- a/main.c
+++ b/main.c
@@ -240,7 +240,7 @@ void close_info(void)
 
 void open_info(void)
 {
-	xpopen_t pfd;
+	spawn_t pfd;
 	char w[12], h[12];
 	char *argv[5];
 
@@ -254,7 +254,7 @@ void open_info(void)
 	argv[2] = w;
 	argv[3] = h;
 	argv[4] = NULL;
-	pfd = xpopen(info.f.cmd, argv, X_READ);
+	pfd = spawn(info.f.cmd, argv, X_READ);
 	if (pfd.readfd >= 0) {
 		fcntl(pfd.readfd, F_SETFL, O_NONBLOCK);
 		info.fd = pfd.readfd;
@@ -516,7 +516,7 @@ static bool run_key_handler(const char *key, unsigned int mask)
 	struct stat *oldst, st;
 	XEvent dump;
 	char *argv[3];
-	xpopen_t pfd;
+	spawn_t pfd;
 
 	if (keyhandler.f.err) {
 		if (!keyhandler.warned) {
@@ -542,7 +542,7 @@ static bool run_key_handler(const char *key, unsigned int mask)
 	argv[0] = keyhandler.f.cmd;
 	argv[1] = kstr;
 	argv[2] = NULL;
-	pfd = xpopen(keyhandler.f.cmd, argv, X_WRITE);
+	pfd = spawn(keyhandler.f.cmd, argv, X_WRITE);
 	if (pfd.writefd < 0)
 		return false;
 	pfs = fdopen(pfd.writefd, "w");

--- a/main.c
+++ b/main.c
@@ -262,7 +262,7 @@ void open_info(void)
 	win.bar.l.buf[0] = '\0';
 	snprintf(w, sizeof(w), "%d", img.w);
 	snprintf(h, sizeof(h), "%d", img.h);
-	construct_argv(argv, ARRLEN(argv), info.f.cmd, (char*)files[fileidx].name, w, h, NULL);
+	construct_argv(argv, ARRLEN(argv), info.f.cmd, files[fileidx].name, w, h, NULL);
 	pfd = spawn(info.f.cmd, argv, X_READ);
 	if (pfd.readfd >= 0) {
 		fcntl(pfd.readfd, F_SETFL, O_NONBLOCK);
@@ -541,13 +541,12 @@ static bool run_key_handler(const char *key, unsigned int mask)
 	strncpy(win.bar.l.buf, "Running key handler...", win.bar.l.size);
 	win_draw(&win);
 	win_set_cursor(&win, CURSOR_WATCH);
+	setenv("NSXIV_USING_NULL", options->using_null ? "1" : "0", 1);
 
 	snprintf(kstr, sizeof(kstr), "%s%s%s%s",
 	         mask & ControlMask ? "C-" : "",
 	         mask & Mod1Mask    ? "M-" : "",
 	         mask & ShiftMask   ? "S-" : "", key);
-	setenv("NSXIV_USING_NULL", options->using_null ? "1" : "0", 1);
-
 	construct_argv(argv, ARRLEN(argv), keyhandler.f.cmd, kstr, NULL);
 	pfd = spawn(keyhandler.f.cmd, argv, X_WRITE);
 	if (pfd.writefd < 0)

--- a/main.c
+++ b/main.c
@@ -254,9 +254,8 @@ void open_info(void)
 	argv[2] = w;
 	argv[3] = h;
 	argv[4] = NULL;
-	pfd = xpopen(info.f.cmd, argv);
-	if (!(pfd.readfd < 0 || pfd.writefd < 0)) {
-		close(pfd.writefd);
+	pfd = xpopen(info.f.cmd, argv, X_READ);
+	if (pfd.readfd >= 0) {
 		fcntl(pfd.readfd, F_SETFL, O_NONBLOCK);
 		info.fd = pfd.readfd;
 		info.i = info.lastsep = 0;
@@ -543,10 +542,9 @@ static bool run_key_handler(const char *key, unsigned int mask)
 	argv[0] = keyhandler.f.cmd;
 	argv[1] = kstr;
 	argv[2] = NULL;
-	pfd = xpopen(keyhandler.f.cmd, argv);
-	if (pfd.readfd < 0 || pfd.writefd < 0)
+	pfd = xpopen(keyhandler.f.cmd, argv, X_WRITE);
+	if (pfd.writefd < 0)
 		return false;
-	close(pfd.readfd);
 	pfs = fdopen(pfd.writefd, "w");
 
 	oldst = emalloc(fcnt * sizeof(*oldst));

--- a/main.c
+++ b/main.c
@@ -545,7 +545,11 @@ static bool run_key_handler(const char *key, unsigned int mask)
 	pfd = spawn(keyhandler.f.cmd, argv, X_WRITE);
 	if (pfd.writefd < 0)
 		return false;
-	pfs = fdopen(pfd.writefd, "w");
+	if ((pfs = fdopen(pfd.writefd, "w")) == NULL) {
+		close(pfd.writefd);
+		error(0, errno, "open pipe");
+		return false;
+	}
 
 	oldst = emalloc(fcnt * sizeof(*oldst));
 	for (f = i = 0; f < fcnt; i++) {

--- a/main.c
+++ b/main.c
@@ -114,19 +114,6 @@ static bool xgetline(char **lineptr, size_t *n)
 	return len > 0;
 }
 
-static void construct_argv(char **argv, unsigned int len, ...)
-{
-	unsigned int i;
-	va_list args;
-
-	va_start(args, len);
-	for (i = 0; i < len; ++i)
-		argv[i] = va_arg(args, char *);
-	va_end(args);
-	if (argv[len-1] != NULL)
-		error(EXIT_FAILURE, 0, "argv not NULL terminated");
-}
-
 static void check_add_file(char *filename, bool given)
 {
 	char *path;

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -363,7 +363,7 @@ int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*, bool);
 int r_mkdir(char*);
-void construct_argv(char **argv, unsigned int len, ...);
+void construct_argv(char **, unsigned int, ...);
 spawn_t spawn(const char *, char *const [], unsigned int);
 
 

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -342,6 +342,12 @@ typedef struct {
 	int stlen;
 } r_dir_t;
 
+typedef struct {
+	int readfd;
+	int writefd;
+	pid_t pid;
+} xpopen_t;
+
 extern const char *progname;
 
 void* emalloc(size_t);
@@ -352,6 +358,7 @@ int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*, bool);
 int r_mkdir(char*);
+xpopen_t xpopen(const char *cmd, const char **argv);
 
 
 /* window.c */

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -346,7 +346,7 @@ typedef struct {
 	int readfd;
 	int writefd;
 	pid_t pid;
-} xpopen_t;
+} spawn_t;
 
 enum {
 	X_READ  = (1 << 0),
@@ -363,7 +363,7 @@ int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*, bool);
 int r_mkdir(char*);
-xpopen_t xpopen(const char *, char *const [], unsigned int);
+spawn_t spawn(const char *, char *const [], unsigned int);
 
 
 /* window.c */

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -348,6 +348,11 @@ typedef struct {
 	pid_t pid;
 } xpopen_t;
 
+enum {
+	X_READ  = (1 << 0),
+	X_WRITE = (1 << 1)
+};
+
 extern const char *progname;
 
 void* emalloc(size_t);
@@ -358,7 +363,7 @@ int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*, bool);
 int r_mkdir(char*);
-xpopen_t xpopen(const char *, char *const []);
+xpopen_t xpopen(const char *, char *const [], unsigned int);
 
 
 /* window.c */

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -363,8 +363,8 @@ int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*, bool);
 int r_mkdir(char*);
-void construct_argv(char **, unsigned int, ...);
-spawn_t spawn(const char *, char *const [], unsigned int);
+void construct_argv(char**, unsigned int, ...);
+spawn_t spawn(const char*, char *const [], unsigned int);
 
 
 /* window.c */

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -358,7 +358,7 @@ int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*, bool);
 int r_mkdir(char*);
-xpopen_t xpopen(const char *cmd, const char **argv);
+xpopen_t xpopen(const char *, char *const []);
 
 
 /* window.c */

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -363,6 +363,7 @@ int r_opendir(r_dir_t*, const char*, bool);
 int r_closedir(r_dir_t*);
 char* r_readdir(r_dir_t*, bool);
 int r_mkdir(char*);
+void construct_argv(char **argv, unsigned int len, ...);
 spawn_t spawn(const char *, char *const [], unsigned int);
 
 

--- a/util.c
+++ b/util.c
@@ -212,12 +212,15 @@ xpopen_t xpopen(const char *cmd, char *const argv[], unsigned int flags)
 	if (cmd == NULL || argv == NULL || flags == 0)
 		return ret;
 
-	if (pipe(pfd_read) < 0)
+	if (pipe(pfd_read) < 0) {
+		error(0, errno, "pipe: %s", cmd);
 		return ret;
+	}
 
 	if (pipe(pfd_write) < 0) {
 		close(pfd_read[0]);
 		close(pfd_read[1]);
+		error(0, errno, "pipe: %s", cmd);
 		return ret;
 	}
 
@@ -237,6 +240,7 @@ xpopen_t xpopen(const char *cmd, char *const argv[], unsigned int flags)
 	if (pid < 0) {
 		close(pfd_read[0]);
 		close(pfd_write[1]);
+		error(0, errno, "fork: %s", cmd);
 		return ret;
 	}
 

--- a/util.c
+++ b/util.c
@@ -225,11 +225,14 @@ spawn_t spawn(const char *cmd, char *const argv[], unsigned int flags)
 	}
 
 	if ((pid = fork()) == 0) {
+		bool err = dup2(pfd_read[1], 1) < 0 || dup2(pfd_write[0], 0) < 0;
 		close(pfd_read[0]);
-		dup2(pfd_read[1], 1);
+		close(pfd_read[1]);
+		close(pfd_write[0]);
 		close(pfd_write[1]);
-		dup2(pfd_write[0], 0);
 
+		if (err)
+			error(EXIT_FAILURE, errno, "dup2: %s", cmd);
 		execv(cmd, argv);
 		error(EXIT_FAILURE, errno, "exec: %s", cmd);
 	}

--- a/util.c
+++ b/util.c
@@ -202,7 +202,7 @@ int r_mkdir(char *path)
 	return 0;
 }
 
-xpopen_t xpopen(const char *cmd, const char **argv)
+xpopen_t xpopen(const char *cmd, char *const argv[])
 {
 	xpopen_t ret = { -1, -1, -1 };
 	int pfd_read[2];

--- a/util.c
+++ b/util.c
@@ -202,9 +202,9 @@ int r_mkdir(char *path)
 	return 0;
 }
 
-xpopen_t xpopen(const char *cmd, char *const argv[], unsigned int flags)
+spawn_t spawn(const char *cmd, char *const argv[], unsigned int flags)
 {
-	xpopen_t ret = { -1, -1, -1 };
+	spawn_t ret = { -1, -1, -1 };
 	int pfd_read[2];
 	int pfd_write[2];
 	pid_t pid;

--- a/util.c
+++ b/util.c
@@ -202,12 +202,15 @@ int r_mkdir(char *path)
 	return 0;
 }
 
-xpopen_t xpopen(const char *cmd, char *const argv[])
+xpopen_t xpopen(const char *cmd, char *const argv[], unsigned int flags)
 {
 	xpopen_t ret = { -1, -1, -1 };
 	int pfd_read[2];
 	int pfd_write[2];
 	pid_t pid;
+
+	if (cmd == NULL || argv == NULL || flags == 0)
+		return ret;
 
 	if (pipe(pfd_read) < 0)
 		return ret;
@@ -238,7 +241,13 @@ xpopen_t xpopen(const char *cmd, char *const argv[])
 	}
 
 	ret.pid = pid;
-	ret.readfd = pfd_read[0];
-	ret.writefd = pfd_write[1];
+	if (flags & X_READ)
+		ret.readfd = pfd_read[0];
+	else
+		close(pfd_read[0]);
+	if (flags & X_WRITE)
+		ret.writefd = pfd_write[1];
+	else
+		close(pfd_write[1]);
 	return ret;
 }

--- a/util.c
+++ b/util.c
@@ -204,24 +204,24 @@ int r_mkdir(char *path)
 
 spawn_t spawn(const char *cmd, char *const argv[], unsigned int flags)
 {
-	spawn_t ret = { -1, -1, -1 };
+	spawn_t status = { -1, -1, -1 };
 	int pfd_read[2];
 	int pfd_write[2];
 	pid_t pid;
 
 	if (cmd == NULL || argv == NULL || flags == 0)
-		return ret;
+		return status;
 
 	if (pipe(pfd_read) < 0) {
 		error(0, errno, "pipe: %s", cmd);
-		return ret;
+		return status;
 	}
 
 	if (pipe(pfd_write) < 0) {
 		close(pfd_read[0]);
 		close(pfd_read[1]);
 		error(0, errno, "pipe: %s", cmd);
-		return ret;
+		return status;
 	}
 
 	if ((pid = fork()) == 0) {
@@ -244,17 +244,17 @@ spawn_t spawn(const char *cmd, char *const argv[], unsigned int flags)
 		close(pfd_read[0]);
 		close(pfd_write[1]);
 		error(0, errno, "fork: %s", cmd);
-		return ret;
+		return status;
 	}
 
-	ret.pid = pid;
+	status.pid = pid;
 	if (flags & X_READ)
-		ret.readfd = pfd_read[0];
+		status.readfd = pfd_read[0];
 	else
 		close(pfd_read[0]);
 	if (flags & X_WRITE)
-		ret.writefd = pfd_write[1];
+		status.writefd = pfd_write[1];
 	else
 		close(pfd_write[1]);
-	return ret;
+	return status;
 }

--- a/util.c
+++ b/util.c
@@ -202,6 +202,19 @@ int r_mkdir(char *path)
 	return 0;
 }
 
+void construct_argv(char **argv, unsigned int len, ...)
+{
+	unsigned int i;
+	va_list args;
+
+	va_start(args, len);
+	for (i = 0; i < len; ++i)
+		argv[i] = va_arg(args, char *);
+	va_end(args);
+	if (argv[len-1] != NULL)
+		error(EXIT_FAILURE, 0, "argv not NULL terminated");
+}
+
 spawn_t spawn(const char *cmd, char *const argv[], unsigned int flags)
 {
 	spawn_t status = { -1, -1, -1 };


### PR DESCRIPTION
As discussed in: https://github.com/nsxiv/nsxiv/issues/210#issuecomment-1027734322 having such abstraction can help us in implementing a couple features in the future.

---

Think the current API should be good enough, but might play around a bit more. Haven't tested this thoroughly yet, so it's possible that this introduces some bug/regression.