### PR TITLE
Prepare for v29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ there may be more changes. Please use `git log` to view them.
 
 - - -
 
+**[v29](https://github.com/nsxiv/nsxiv/archive/v29.tar.gz)**
+*(TODO: put date in here)*
+
+* Changes:
+
+  * Imlib2 cache size is now set based on total memory percentage, by default
+    set to 3%. (#184)
+
+* Added:
+
+  * Ability to customize thumbnail mode mouse-bindings via `config.h`. (#167)
+  * New keybinding <kbd>z</kbd> to scroll to center. (#203)
+
+* Fixes:
+
+  * Manpage cleanup: avoid confusing wording and document thumbnail mode
+    mouse-bindings. (#186)
+  * Wrong jpeg exif orientation with `Imlib2 v1.7.5`. (#188)
+  * Animation slowdown when zoomed in. (#200)
+  * Reset statusbar after failed keyhandler. (#191)
+  * Various compiler warnings. (#197)
+
+- - -
+
 **[v28](https://github.com/nsxiv/nsxiv/archive/v28.tar.gz)**
 *(December 12, 2021)*
 


### PR DESCRIPTION
Since Imlib2 v1.8.0 was released two days ago, we should wait maybe a week or two to see if any incompatibility issues like #188 arises.

There's a good amount of bugfixes currently in `master` so I think it's meaningful to release a new version, despite it being much smaller than what we've previously been doing.

As a sidenote: I'm sort of expecting our releases to become smaller and/or time between releases to become larger since we've decided to stick close to sxiv, which cuts down a lot of possibility of becoming bloated. OTOH it also cuts down ability add some *useful* features as well, but IMO it's a decent tradeoff.

Checklist:

- [ ] Open PRs to be merged: https://github.com/nsxiv/nsxiv/milestone/2
- [ ] Update the date in CHANGELOG
- [ ] Update VERSION in Makefile



