### PR TITLE
Makefile: cleanup non-posix stuff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install libimlib2 libimlib2-dev xserver-xorg-core xserver-xorg-dev \
                              libxft2 libxft-dev libexif12 libexif-dev \
-                             gcc clang
+                             gcc clang git
         TCC_SHA="027b8fb9b88fe137447fb8bb1b61079be9702472"
         wget "https://github.com/TinyCC/tinycc/archive/${TCC_SHA}.tar.gz" && tar xzf "${TCC_SHA}.tar.gz"
         ( cd "tinycc-$TCC_SHA" && ./configure && make && sudo make install; )
@@ -32,12 +32,9 @@ jobs:
         CFLAGS+=" -Wbad-function-cast -Wdeclaration-after-statement"
         # silence
         CFLAGS+=" -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers"
-        export CFLAGS
-        export LDFLAGS="$CFLAGS"
-        export OPT_DEP_DEFAULT=1
-        echo "###  GCC BUILD  ###" && make clean && CC=gcc   make -s
-        echo "### CLANG BUILD ###" && make clean && CC=clang make -s
-        echo "###  TCC BUILD  ###" && make clean && CC=tcc   make -s
+        echo "###  GCC BUILD  ###" && make clean && make -s CC=gcc   CFLAGS="$CFLAGS" LDFLAGS="$CFLAGS" OPT_DEP_DEFAULT=1
+        echo "### CLANG BUILD ###" && make clean && make -s CC=clang CFLAGS="$CFLAGS" LDFLAGS="$CFLAGS" OPT_DEP_DEFAULT=1
+        echo "###  TCC BUILD  ###" && make clean && make -s CC=tcc   CFLAGS="$CFLAGS" LDFLAGS="$CFLAGS" OPT_DEP_DEFAULT=1
 
   minimal-build:
     runs-on: ubuntu-latest
@@ -47,7 +44,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libimlib2 libimlib2-dev xserver-xorg-core xserver-xorg-dev \
-                             gcc clang
+                             gcc clang git
         sudo apt-get remove libxft2 libxft-dev libexif12 libexif-dev
         TCC_SHA="027b8fb9b88fe137447fb8bb1b61079be9702472"
         wget "https://github.com/TinyCC/tinycc/archive/${TCC_SHA}.tar.gz" && tar xzf "${TCC_SHA}.tar.gz"
@@ -63,9 +60,6 @@ jobs:
         CFLAGS+=" -Wbad-function-cast -Wdeclaration-after-statement"
         # silence
         CFLAGS+=" -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers"
-        export CFLAGS
-        export LDFLAGS="$CFLAGS"
-        export OPT_DEP_DEFAULT=0
-        echo "###  GCC BUILD  ###" && make clean && CC=gcc   make -s
-        echo "### CLANG BUILD ###" && make clean && CC=clang make -s
-        echo "###  TCC BUILD  ###" && make clean && CC=tcc   make -s
+        echo "###  GCC BUILD  ###" && make clean && make -s CC=gcc   CFLAGS="$CFLAGS" LDFLAGS="$CFLAGS" OPT_DEP_DEFAULT=0
+        echo "### CLANG BUILD ###" && make clean && make -s CC=clang CFLAGS="$CFLAGS" LDFLAGS="$CFLAGS" OPT_DEP_DEFAULT=0
+        echo "###  TCC BUILD  ###" && make clean && make -s CC=tcc   CFLAGS="$CFLAGS" LDFLAGS="$CFLAGS" OPT_DEP_DEFAULT=0

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ config.h:
 
 version.h: Makefile .git/index
 	@echo "GEN $@"
-	v="$$(git describe 2>/dev/null)"; \
+	v="$$(git describe 2>/dev/null || true)"; \
 	echo "#define VERSION \"$${v:-$(VERSION)}\"" >$@
 
 .git/index:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ NSXIV_LDLIBS = -lImlib2 -lX11 \
 OBJS = autoreload_$(autoreload_$(HAVE_INOTIFY)).o commands.o image.o main.o options.o \
   thumbs.o util.o window.o
 
-.PHONY: all clean install uninstall install-all install-icon uninstall-icon install-desktop
 .SUFFIXES:
 .SUFFIXES: .c .o
 

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,27 @@
+.POSIX:
+
 # nsxiv version
 VERSION = 28
 
 # PREFIX for install
-PREFIX ?= /usr/local
-MANPREFIX ?= $(PREFIX)/share/man
-EGPREFIX ?= $(PREFIX)/share/doc/nsxiv/examples
+PREFIX = /usr/local
+MANPREFIX = $(PREFIX)/share/man
+EGPREFIX = $(PREFIX)/share/doc/nsxiv/examples
 
 # default value for optional dependencies. 1 = enabled, 0 = disabled
-OPT_DEP_DEFAULT ?= 1
+OPT_DEP_DEFAULT = 1
 
 # autoreload backend: 1 = inotify, 0 = none
-HAVE_INOTIFY ?= $(OPT_DEP_DEFAULT)
+HAVE_INOTIFY = $(OPT_DEP_DEFAULT)
 
 # optional dependencies, see README for more info
-HAVE_LIBFONTS ?= $(OPT_DEP_DEFAULT)
-HAVE_LIBGIF ?= $(OPT_DEP_DEFAULT)
-HAVE_LIBEXIF ?= $(OPT_DEP_DEFAULT)
-HAVE_LIBWEBP ?= $(OPT_DEP_DEFAULT)
+HAVE_LIBFONTS = $(OPT_DEP_DEFAULT)
+HAVE_LIBGIF   = $(OPT_DEP_DEFAULT)
+HAVE_LIBEXIF  = $(OPT_DEP_DEFAULT)
+HAVE_LIBWEBP  = $(OPT_DEP_DEFAULT)
 
 # CFLAGS, any optimization flags goes here
-CFLAGS ?= -std=c99 -Wall -pedantic
+CFLAGS = -std=c99 -Wall -pedantic
 
 # icons that will be installed via `make icon`
 ICONS = 16x16.png 32x32.png 48x48.png 64x64.png 128x128.png
@@ -42,8 +44,8 @@ lib_webp_0 =
 lib_webp_1 = -lwebpdemux -lwebp
 autoreload_0 = nop
 autoreload_1 = inotify
-# using += because certain *BSD distros may need to add additional flags
-LDLIBS += -lImlib2 -lX11 \
+
+NSXIV_LDLIBS = -lImlib2 -lX11 \
   $(lib_exif_$(HAVE_LIBEXIF)) $(lib_gif_$(HAVE_LIBGIF)) \
   $(lib_webp_$(HAVE_LIBWEBP)) $(lib_fonts_$(HAVE_LIBFONTS))
 
@@ -58,7 +60,7 @@ all: nsxiv
 
 nsxiv: $(OBJS)
 	@echo "LINK $@"
-	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LDLIBS) $(NSXIV_LDLIBS)
 
 .c.o:
 	@echo "CC $@"


### PR DESCRIPTION
removes some non-posix extensions which slipped through.

users can always overwrite the variables explicitly by using
`make VAR=VALUE`

packagers can also add extra libs to LDLIBS, we're internally using
NSXIV_LDLIBS now.