### PR TITLE
add native pipe support with memfd_create()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ HAVE_LIBFONTS = $(OPT_DEP_DEFAULT)
 HAVE_LIBGIF   = $(OPT_DEP_DEFAULT)
 HAVE_LIBEXIF  = $(OPT_DEP_DEFAULT)
 HAVE_LIBWEBP  = $(OPT_DEP_DEFAULT)
+HAVE_MEMFD    = $(OPT_DEP_DEFAULT)
 
 # CFLAGS, any optimization flags goes here
 CFLAGS = -std=c99 -Wall -pedantic
@@ -28,11 +29,14 @@ ICONS = 16x16.png 32x32.png 48x48.png 64x64.png 128x128.png
 
 inc_fonts_0 =
 inc_fonts_1 = -I/usr/include/freetype2 -I$(PREFIX)/include/freetype2
+memfd_cppflag_0 =
+memfd_cppflag_1 = -D_GNU_SOURCE
 
 CPPFLAGS = -D_XOPEN_SOURCE=700 \
   -DHAVE_LIBGIF=$(HAVE_LIBGIF) -DHAVE_LIBEXIF=$(HAVE_LIBEXIF) \
   -DHAVE_LIBWEBP=$(HAVE_LIBWEBP) -DHAVE_LIBFONTS=$(HAVE_LIBFONTS) \
-  $(inc_fonts_$(HAVE_LIBFONTS))
+  -DHAVE_MEMFD=$(HAVE_MEMFD) \
+  $(memfd_cppflag_$(HAVE_MEMFD)) $(inc_fonts_$(HAVE_LIBFONTS))
 
 lib_fonts_0 =
 lib_fonts_1 = -lXft -lfontconfig

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The following dependencies are optional.
 
   * inotify : Used for auto-reloading images on change.
     Disabled via `HAVE_INOTIFY=0`
+  * memfd\_create : Used for pipe support. See FAQ for more details.
+    Disabled via `HAVE_MEMFD=0`
   * libXft, freetype2, fontconfig : Used for the status bar.
     Disabled via `HAVE_LIBFONTS=0`
   * giflib : Used for animated gif playback.
@@ -77,7 +79,7 @@ The following dependencies are optional.
     Disable via `HAVE_LIBEXIF=0`
   * libwebp : Used for animated webp playback.
     (NOTE: animated webp also requires Imlib2 v1.7.5 or above)
-    Disabled via `HAVE_LIBWEBP=0`.
+    Disabled via `HAVE_LIBWEBP=0`
 
 Please make sure to install the corresponding development packages in case that
 you want to build nsxiv on a distribution with separate runtime and development
@@ -160,7 +162,9 @@ Yes, see [nsxiv-rifle](https://github.com/nsxiv/nsxiv-extra/tree/master/scripts/
 Yes, see [nsxiv-env](https://github.com/nsxiv/nsxiv-extra/tree/master/scripts/nsxiv-env)
 
 * Can I pipe images into nsxiv? <br>
-Yes, see [nsxiv-pipe](https://github.com/nsxiv/nsxiv-extra/tree/master/scripts/nsxiv-pipe)
+Yes, since nsxiv v30, also requires Imlib2 v1.7.0+ and `memfd_create()` which
+is Linux specific. For non-linux OSes, see
+[nsxiv-pipe](https://github.com/nsxiv/nsxiv-extra/tree/master/scripts/nsxiv-pipe)
 
 * nsxiv crashes when viewing images with emojis in their name. <br>
 This is an issue with libXft. Either wait for

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -108,12 +108,14 @@ typedef enum {
 typedef enum {
 	FF_WARN    = 1,
 	FF_MARK    = 2,
-	FF_TN_INIT = 4
+	FF_TN_INIT = 4,
+	FF_PIPE    = 8
 } fileflags_t;
 
 typedef struct {
 	const char *name; /* as given by user */
 	const char *path; /* always absolute */
+	int fd;
 	fileflags_t flags;
 } fileinfo_t;
 

--- a/options.c
+++ b/options.c
@@ -192,7 +192,10 @@ void parse_options(int argc, char **argv)
 	_options.filenames = argv + optind;
 	_options.filecnt = argc - optind;
 
-	if (_options.filecnt == 1 && STREQ(_options.filenames[0], "-")) {
+	if (_options.filecnt == 0 && !isatty(0)) {
+		_options.filecnt++;
+		_options.filenames[0] = estrdup("/dev/stdin");
+	} else if (_options.filecnt == 1 && STREQ(_options.filenames[0], "-")) {
 		_options.filenames++;
 		_options.filecnt--;
 		_options.from_stdin = true;


### PR DESCRIPTION
caveat: memfd_create() is linux specific afaik and not available in
*BSDs and other *nix OSes.

Closes: https://github.com/nsxiv/nsxiv/issues/32

---

I've thought about having this as a patch since memfd_create is linux specific, but then again we also have inotify which is linux specific so just having it a compile time option doesn't seem too out of character.