### PR TITLE
Fix various statusbar issues

### DIFF
--- a/main.c
+++ b/main.c
@@ -618,10 +618,10 @@ static bool run_key_handler(const char *key, unsigned int mask)
 		if (changed) {
 			img_close(&img, true);
 			load_image(fileidx);
-		} else {
-			open_info();
 		}
 	}
+	if (mode == MODE_THUMB || !changed)
+		open_info();
 	free(oldst);
 	reset_cursor();
 	return true;

--- a/main.c
+++ b/main.c
@@ -400,7 +400,7 @@ static void update_info(void)
 	win_bar_t *l = &win.bar.l, *r = &win.bar.r;
 
 	/* update bar contents */
-	if (win.bar.h == 0)
+	if (win.bar.h == 0 || extprefix)
 		return;
 	for (fw = 0, i = filecnt; i > 0; fw++, i /= 10);
 	mark = files[fileidx].flags & FF_MARK ? "* " : "";


### PR DESCRIPTION
#### fix: broken thumbnail statusbar after running keyhandler

---

#### fix: broken statusbar after key-handler cancellation

to reproduce:
1. have an image-info script
2. invoke the key-handler
3. cancle invocation by pressing `escape`

at this point, the statusbar ends up being empty.

the regression seems to be caused by 6922d5d (changing select to poll),
unsure why that is.

in any case, this simplifies read_info quite a bit and solves the
regression as well. in short:

* read straight into the statusbar buffer
* if read succeeds, make sure buffer is null terminated and replace any
  newline with space
* close the script

---

#### fix: don't override statusbar if info script doesn't exist

this happens when the keyhandler is invoked while viewing an animated
image. if {image,thumb}-info scripts exists, everything works as
expected. but if they don't, then update_info will override the
statusbar.
