### PR TITLE
check_timeouts: avoid unnecessary conversions

### DIFF
--- a/main.c
+++ b/main.c
@@ -207,7 +207,7 @@ void reset_timeout(timeout_f handler)
 	}
 }
 
-static bool check_timeouts(struct timeval *t)
+static bool check_timeouts(int *t)
 {
 	int i = 0, tdiff, tmin = -1;
 	struct timeval now;
@@ -228,7 +228,7 @@ static bool check_timeouts(struct timeval *t)
 		i++;
 	}
 	if (tmin > 0 && t != NULL)
-		TV_SET_MSEC(t, tmin);
+		*t = tmin;
 	return tmin > 0;
 }
 
@@ -703,7 +703,7 @@ static void run(void)
 {
 	enum { FD_X, FD_INFO, FD_ARL, FD_CNT };
 	struct pollfd pfd[FD_CNT];
-	struct timeval timeout = {0};
+	int timeout = 0;
 	const struct timespec ten_ms = {0, 10000000};
 	bool discard, init_thumb, load_thumb, to_set;
 	XEvent ev, nextev;
@@ -735,7 +735,7 @@ static void run(void)
 				pfd[FD_ARL].fd = arl.fd;
 				pfd[FD_X].events = pfd[FD_INFO].events = pfd[FD_ARL].events = POLLIN;
 
-				if (poll(pfd, ARRLEN(pfd), to_set ? TV_TO_MS(&timeout) : -1) < 0)
+				if (poll(pfd, ARRLEN(pfd), to_set ? timeout : -1) < 0)
 					continue;
 				if (pfd[FD_INFO].revents & POLLIN)
 					read_info();

--- a/nsxiv.h
+++ b/nsxiv.h
@@ -44,12 +44,6 @@
 
 #define TV_DIFF(t1,t2) (((t1)->tv_sec  - (t2)->tv_sec ) * 1000 + \
                         ((t1)->tv_usec - (t2)->tv_usec) / 1000)
-#define TV_TO_MS(tv)   (((tv)->tv_sec * 1000) + ((tv)->tv_usec / 1000))
-
-#define TV_SET_MSEC(tv,t) {             \
-  (tv)->tv_sec  = (t) / 1000;           \
-  (tv)->tv_usec = (t) % 1000 * 1000;    \
-}
 
 #define TV_ADD_MSEC(tv,t) {             \
   (tv)->tv_sec  += (t) / 1000;          \


### PR DESCRIPTION
before we were using select, which expected `struct timeval` as
arg. so we needed to do ms -> timeval conversions.

but now since we're using poll, which accepts milisec as arg, there's
not need to do ms -> timeval -> ms. instead have check_timeouts directly
return ms.