### PR TITLE
Makefile: add utf8.h as window.o dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ nsxiv: $(OBJS)
 
 $(OBJS): Makefile nsxiv.h config.h commands.h
 options.o: version.h
-window.o: icon/data.h
+window.o: icon/data.h utf8.h
 
 config.h:
 	@echo "GEN $@"


### PR DESCRIPTION
unlikely for utf8.h to change, other than syncing with upstream, but
doesn't hurt tracking it either ways.