### PR TITLE
fix: broken slideshow if redraw takes too long

### DIFF
--- a/main.c
+++ b/main.c
@@ -88,8 +88,8 @@ static struct {
 static timeout_t timeouts[] = {
 	{ { 0, 0 }, false, redraw       },
 	{ { 0, 0 }, false, reset_cursor },
-	{ { 0, 0 }, false, animate      },
 	{ { 0, 0 }, false, slideshow    },
+	{ { 0, 0 }, false, animate      },
 	{ { 0, 0 }, false, clear_resize },
 };
 


### PR DESCRIPTION
currently the way check_timeout() is implemented, animate has higher
priority than slideshow. so if doing a redraw takes longer than the
frame delay of the animated image then it's going to continuously keep
animating and never reliably get to slideshow.

this issue can occur if the animated image has too fast of a delay or if
nsxiv is being run on a slow system where doing redraw takes too long.
the issue can be emulated by artificially slowing down img_render by
sticking a sleep in there.

	diff --git a/main.c b/main.c
	index 5dc52d4..0580011 100644
	--- a/main.c
	+++ b/main.c
	@@ -441,6 +441,7 @@ void redraw(void)

	 	if (mode == MODE_IMAGE) {
	 		img_render(&img);
	+		nanosleep(&(struct timespec){0, 62000000}, NULL); /* 62ms */
	 		if (img.ss.on) {
	 			t = img.ss.delay * 100;
	 			if (img.multi.cnt > 0 && img.multi.animate)

make it so that slideshow has higher priority than animate to avoid it
from happening.

Closes: https://github.com/nsxiv/nsxiv/issues/281